### PR TITLE
feat: add auto reload on restart

### DIFF
--- a/src/server/constants.ts
+++ b/src/server/constants.ts
@@ -1,4 +1,6 @@
 export const INTERNAL_PREFIX = "/_frsh";
+export const REFRESH_JS_URL = `${INTERNAL_PREFIX}/refresh.js`;
+export const ALIVE_URL = `${INTERNAL_PREFIX}/alive`;
 export const BUILD_ID = Deno.env.get("DENO_DEPLOYMENT_ID") ||
   crypto.randomUUID();
 export const JS_PREFIX = `/js`;

--- a/src/server/context.ts
+++ b/src/server/context.ts
@@ -21,6 +21,7 @@ import {
 import { render as internalRender } from "./render.tsx";
 
 export class ServerContext {
+  #dev: boolean;
   #pages: Page[];
   #staticFiles: [URL, string][];
   #bundler: Bundler;
@@ -35,6 +36,7 @@ export class ServerContext {
     this.#staticFiles = staticFiles;
     this.#renderer = renderer;
     this.#bundler = new Bundler(pages);
+    this.#dev = typeof Deno.env.get("DENO_DEPLOYMENT_ID") !== "string"; // Env var is only set in prod (on Deploy).
   }
 
   /**
@@ -139,6 +141,9 @@ export class ServerContext {
     for (const page of this.#pages) {
       const bundlePath = `/${page.name}.js`;
       const imports = page.runtimeJS ? [bundleAssetUrl(bundlePath)] : [];
+      if (this.#dev) {
+        imports.push(`${INTERNAL_PREFIX}/refresh.js`);
+      }
       const createRender = (
         req: Request,
         params: Record<string, string | string[]>,
@@ -199,6 +204,39 @@ export class ServerContext {
 
     routes[`${INTERNAL_PREFIX}${JS_PREFIX}/${BUILD_ID}/:path*`] = this
       .#bundleAssetRoute();
+
+    if (this.#dev) {
+      routes[`${INTERNAL_PREFIX}/refresh.js`] = () => {
+        const js =
+          `const buildId = "${BUILD_ID}"; new EventSource("${INTERNAL_PREFIX}/alive").addEventListener("message", (e) => { if (e.data !== buildId) { location.reload(); } });`;
+        return new Response(new TextEncoder().encode(js), {
+          headers: {
+            "content-type": "application/javascript; charset=utf-8",
+          },
+        });
+      };
+      routes[`${INTERNAL_PREFIX}/alive`] = () => {
+        let timerId: number | undefined = undefined;
+        const body = new ReadableStream({
+          start(controller) {
+            controller.enqueue(`data: ${BUILD_ID}\nretry: 100\n\n`);
+            timerId = setInterval(() => {
+              controller.enqueue(`data: ${BUILD_ID}\n\n`);
+            }, 1000);
+          },
+          cancel() {
+            if (timerId !== undefined) {
+              clearInterval(timerId);
+            }
+          },
+        });
+        return new Response(body.pipeThrough(new TextEncoderStream()), {
+          headers: {
+            "content-type": "text/event-stream",
+          },
+        });
+      };
+    }
 
     return routes;
   }

--- a/src/server/context.ts
+++ b/src/server/context.ts
@@ -8,7 +8,7 @@ import {
 } from "./deps.ts";
 import { Routes } from "./mod.ts";
 import { Bundler } from "./bundle.ts";
-import { INTERNAL_PREFIX } from "./constants.ts";
+import { ALIVE_URL, INTERNAL_PREFIX, REFRESH_JS_URL } from "./constants.ts";
 import { JS_PREFIX } from "./constants.ts";
 import { BUILD_ID } from "./constants.ts";
 import {
@@ -142,7 +142,7 @@ export class ServerContext {
       const bundlePath = `/${page.name}.js`;
       const imports = page.runtimeJS ? [bundleAssetUrl(bundlePath)] : [];
       if (this.#dev) {
-        imports.push(`${INTERNAL_PREFIX}/refresh.js`);
+        imports.push(REFRESH_JS_URL);
       }
       const createRender = (
         req: Request,
@@ -206,16 +206,16 @@ export class ServerContext {
       .#bundleAssetRoute();
 
     if (this.#dev) {
-      routes[`${INTERNAL_PREFIX}/refresh.js`] = () => {
+      routes[REFRESH_JS_URL] = () => {
         const js =
-          `const buildId = "${BUILD_ID}"; new EventSource("${INTERNAL_PREFIX}/alive").addEventListener("message", (e) => { if (e.data !== buildId) { location.reload(); } });`;
+          `const buildId = "${BUILD_ID}"; new EventSource("${ALIVE_URL}").addEventListener("message", (e) => { if (e.data !== buildId) { location.reload(); } });`;
         return new Response(new TextEncoder().encode(js), {
           headers: {
             "content-type": "application/javascript; charset=utf-8",
           },
         });
       };
-      routes[`${INTERNAL_PREFIX}/alive`] = () => {
+      routes[ALIVE_URL] = () => {
         let timerId: number | undefined = undefined;
         const body = new ReadableStream({
           start(controller) {

--- a/src/server/render.tsx
+++ b/src/server/render.tsx
@@ -7,6 +7,7 @@ import { Page, Renderer } from "./types.ts";
 import { PageProps } from "../runtime/types.ts";
 import { SUSPENSE_CONTEXT } from "../runtime/suspense.ts";
 import { HEAD_CONTEXT } from "../runtime/head.ts";
+import { REFRESH_JS_URL } from "./constants.ts";
 
 export interface RenderOptions {
   page: Page;
@@ -172,7 +173,10 @@ export async function* render(opts: RenderOptions): AsyncIterable<string> {
 
   // If this is a static render (runtimeJS is false), then we don't need to
   // render the props into the template.
-  if (opts.imports.length === 0) {
+  if (
+    opts.imports.length === 0 ||
+    (opts.imports.length === 1 && opts.imports[0] === REFRESH_JS_URL)
+  ) {
     templateProps = undefined;
   }
 

--- a/tests/main_test.ts
+++ b/tests/main_test.ts
@@ -120,7 +120,6 @@ Deno.test("/static page prerender", async () => {
   assertEquals(resp.headers.get("content-type"), "text/html; charset=utf-8");
   const body = await resp.text();
   assert(!body.includes(`static.js`));
-  assert(!body.includes(`</script>`));
   assertStringIncludes(body, "<p>This is a static page.</p>");
   assert(!body.includes("__FRSH_PROPS"));
 });


### PR DESCRIPTION
This commit adds support for auto reloading open pages when fresh
restarts. This is particularly useful when `deno run` is used with
`--watch`.
