### PR TITLE
refactor: enhances the old Error-Handling system 

### DIFF
--- a/init.ts
+++ b/init.ts
@@ -1,22 +1,20 @@
 import { gte, join, parse, resolve } from "./src/dev/deps.ts";
-import { error } from "./src/dev/error.ts";
+import { Fout } from "./src/dev/error.ts";
 import { collect, generate } from "./src/dev/mod.ts";
 
 const MIN_VERSION = "1.23.0";
 
 // Check that the minimum supported Deno version is being used.
 if (!gte(Deno.version.deno, MIN_VERSION)) {
-  let message =
-    `Deno version ${MIN_VERSION} or higher is required. Please update Deno.\n\n`;
-
-  if (Deno.execPath().includes("homebrew")) {
-    message +=
-      "You seem to have installed Deno via homebrew. To update, run: `brew upgrade deno`\n";
-  } else {
-    message += "To update, run: `deno upgrade`\n";
-  }
-
-  error(message);
+  Fout(
+    `Deno version ${MIN_VERSION} or higher is required. Please update Deno.\n\n`,
+    {
+      errId: "legacy-ver",
+      note: (Deno.execPath().includes("homebrew")
+        ? "You seem to have installed Deno via homebrew. To update, run: `brew upgrade deno`\n"
+        : "To update, run: `deno upgrade`\n"),
+    },
+  );
 }
 
 const help = `fresh-init
@@ -53,7 +51,9 @@ const flags = parse(Deno.args, {
 });
 
 if (flags._.length !== 1) {
-  error(help);
+  Fout("Couldn't parse passed flags", {
+    note: "Proper usage:\n" + help,
+  });
 }
 
 const unresolvedDirectory = Deno.args[0];
@@ -67,7 +67,7 @@ try {
     !isEmpty &&
     !(flags.force === null ? confirm(CONFIRM_EMPTY_MESSAGE) : flags.force)
   ) {
-    error("Directory is not empty.");
+    Fout("Directory is not empty.");
   }
 } catch (err) {
   if (!(err instanceof Deno.errors.NotFound)) {

--- a/src/dev/deps.ts
+++ b/src/dev/deps.ts
@@ -1,5 +1,6 @@
 // std
 export {
+  basename,
   dirname,
   extname,
   fromFileUrl,
@@ -10,3 +11,4 @@ export {
 export { walk } from "https://deno.land/std@0.150.0/fs/walk.ts";
 export { parse } from "https://deno.land/std@0.150.0/flags/mod.ts";
 export { gte } from "https://deno.land/std@0.150.0/semver/mod.ts";
+export { bgRed, dim, red } from "https://deno.land/std@0.151.0/fmt/colors.ts";

--- a/src/dev/error.ts
+++ b/src/dev/error.ts
@@ -1,8 +1,46 @@
-export function printError(message: string) {
-  console.error(`%cerror%c: ${message}`, "color: red; font-weight: bold", "");
+import { basename, bgRed, dim, red } from "./deps.ts";
+
+interface iOptional {
+  errId?: string;
+  note?: string;
+  hardRejection?: boolean;
 }
 
-export function error(message: string): never {
-  printError(message);
-  Deno.exit(1);
+/**
+ * Fout: a rust-like error handler.
+ * @param errMsg error message to display
+ * @param extras optional params
+ *
+ * @example
+ * ```
+ * Fout("A fatal unknown error!", {
+ *   errId: "Fout-69",
+ *   note: "There's a way to fix this... But it may hurt ;D",
+ *   hardRejection: true
+ * });
+ * ```
+ */
+export function Fout(errMsg: string, extras?: iOptional): void {
+  const options = {
+    hardRejection: true,
+    ...extras,
+  };
+
+  const errorIdNumber = options.errId ? `[${options.errId}]\n` : "\n";
+
+  let errLog = bgRed("Error" + errorIdNumber);
+  errLog += dim("--> stackTrace: " + basename(import.meta.url));
+  errLog += `\n |\n | ${red(errMsg)}\n |\n`;
+
+  options.note !== undefined
+    ? errLog += ` = Note: ${options.note}\n\n`
+    : errLog += " = ";
+
+  options.hardRejection === true
+    ? errLog += red("log: aborting due to previous error...")
+    : errLog += red("log: ignoring said error...");
+
+  console.error(errLog);
+
+  options.hardRejection && Deno.exit(1);
 }

--- a/src/dev/mod.ts
+++ b/src/dev/mod.ts
@@ -6,7 +6,7 @@ import {
   toFileUrl,
   walk,
 } from "./deps.ts";
-import { error } from "./error.ts";
+import { Fout } from "./error.ts";
 
 interface Manifest {
   routes: string[];
@@ -52,9 +52,10 @@ export async function collect(directory: string): Promise<Manifest> {
     const islandsUrl = toFileUrl(islandsDir);
     for await (const entry of Deno.readDir(islandsDir)) {
       if (entry.isDirectory) {
-        error(
-          `Found subdirectory '${entry.name}' in islands/. The islands/ folder must not contain any subdirectories.`,
-        );
+        Fout(`Found subdirectory '${entry.name}' in islands/ dir.`, {
+          errId: "wrong-usage",
+          note: "The islands/ folder must not contain any subdirectories.",
+        });
       }
       if (entry.isFile) {
         const ext = extname(entry.name);


### PR DESCRIPTION
# About this PR
This PR makes small refactors & changes to the current error handling/displaying system, making it look more elegant while keeping it minimal.
The refactor doesn't strip out the simplicity given by the old one for it can still be achieved through 1-line, while providing more context to others devs...

# Example > Advanced Usage:
```ts
Fout("Some very important error", {
  errId: "fout-69", // > could be used to refer to common errors using the wiki
  note: "A small message regarding the way to fix this error", // usually a suggested fix
  hardRejection: true
               // ^ default value
});
```

# Example > One Liner:
```ts
Fout("Another unknown error");
```

# Expected Output:
```txt
Error[$errId]
--> $stackTrace
|
| $errMsg
|
= Note: $note

log: aborting due to previous error... (variable output [based on hardRejection])
```

# Why name it "Fout"
Fout is a Dutch word meaning error/mistake, inspiration was taken on that basis and named like that...