### PR TITLE
fix: dev command loading snapshot

### DIFF
--- a/src/dev/dev_command.ts
+++ b/src/dev/dev_command.ts
@@ -1,8 +1,13 @@
 import { updateCheck } from "./update_check.ts";
-import { DAY, dirname, fromFileUrl, join } from "./deps.ts";
-import { FreshOptions } from "../server/mod.ts";
+import { DAY, dirname, fromFileUrl, fs, join, toFileUrl } from "./deps.ts";
+import {
+  FreshOptions,
+  Manifest as ServerManifest,
+  ServerContext,
+} from "../server/mod.ts";
 import { build } from "./build.ts";
 import { collect, ensureMinDenoVersion, generate, Manifest } from "./mod.ts";
+import { startFromContext } from "../server/boot.ts";
 
 export async function dev(
   base: string,
@@ -34,9 +39,28 @@ export async function dev(
 
   if (manifestChanged) await generate(dir, newManifest);
 
-  if (Deno.args.includes("build")) {
+  const manifest = (await import(toFileUrl(join(dir, "fresh.gen.ts")).href))
+    .default as ServerManifest;
+
+  const outDir = join(dir, "_fresh");
+
+  const isBuild = Deno.args.includes("build");
+  const ctx = await ServerContext.fromManifest(manifest, {
+    ...options,
+    skipSnapshot: true,
+    dev: !isBuild,
+  });
+
+  if (isBuild) {
+    // Ensure that build dir is empty
+    await fs.emptyDir(outDir);
     await build(join(dir, "fresh.gen.ts"), options);
+  } else if (options) {
+    await startFromContext(ctx, options);
   } else {
+    // Legacy entry point: Back then `dev.ts` would call `main.ts` but
+    // this causes duplicate plugin instantiation if both `dev.ts` and
+    // `main.ts` instantiate plugins.
     await import(entrypoint);
   }
 }

--- a/src/server/boot.ts
+++ b/src/server/boot.ts
@@ -1,0 +1,68 @@
+import { ServerContext } from "./context.ts";
+import { colors } from "./deps.ts";
+import { ServeHandler, StartOptions } from "./types.ts";
+
+export async function startFromContext(ctx: ServerContext, opts: StartOptions) {
+  if (!opts.onListen) {
+    opts.onListen = (params) => {
+      console.log();
+      console.log(
+        colors.bgRgb8(colors.black(colors.bold(" 🍋 Fresh ready ")), 121),
+      );
+
+      const address = colors.cyan(`http://localhost:${params.port}/`);
+      const localLabel = colors.bold("Local:");
+      console.log(`    ${localLabel} ${address}\n`);
+    };
+  }
+
+  const portEnv = Deno.env.get("PORT");
+  if (portEnv !== undefined) {
+    opts.port ??= parseInt(portEnv, 10);
+  }
+
+  const handler = ctx.handler();
+
+  if (opts.port) {
+    await bootServer(handler, opts);
+  } else {
+    // No port specified, check for a free port. Instead of picking just
+    // any port we'll check if the next one is free for UX reasons.
+    // That way the user only needs to increment a number when running
+    // multiple apps vs having to remember completely different ports.
+    let firstError;
+    for (let port = 8000; port < 8020; port++) {
+      try {
+        await bootServer(handler, { ...opts, port });
+        firstError = undefined;
+        break;
+      } catch (err) {
+        if (err instanceof Deno.errors.AddrInUse) {
+          // Throw first EADDRINUSE error
+          // if no port is free
+          if (!firstError) {
+            firstError = err;
+          }
+          continue;
+        }
+
+        throw err;
+      }
+    }
+
+    if (firstError) {
+      throw firstError;
+    }
+  }
+}
+
+async function bootServer(handler: ServeHandler, opts: StartOptions) {
+  // @ts-ignore Ignore type error when type checking with Deno versions
+  if (typeof Deno.serve === "function") {
+    // @ts-ignore Ignore type error when type checking with Deno versions
+    await Deno.serve(opts, handler).finished;
+  } else {
+    // @ts-ignore Deprecated std serve way
+    await serve(handler, opts);
+  }
+}

--- a/src/server/context.ts
+++ b/src/server/context.ts
@@ -148,7 +148,7 @@ export class ServerContext {
    */
   static async fromManifest(
     manifest: Manifest,
-    opts: FreshOptions & { skipSnapshot?: boolean },
+    opts: FreshOptions & { skipSnapshot?: boolean; dev?: boolean },
   ): Promise<ServerContext> {
     // Get the manifest' base URL.
     const baseUrl = new URL("./", manifest.baseUrl).href;
@@ -436,7 +436,7 @@ export class ServerContext {
       }
     }
 
-    const dev = isDevMode();
+    const dev = opts.dev ?? isDevMode();
     if (dev) {
       // Ensure that debugging hooks are set up for SSR rendering
       await import("preact/debug");

--- a/src/server/mod.ts
+++ b/src/server/mod.ts
@@ -2,7 +2,6 @@ import { LayoutConfig } from "$fresh/server.ts";
 import { ComponentChildren } from "preact";
 import { ServerContext } from "./context.ts";
 export { Status } from "./deps.ts";
-import { colors, serve } from "./deps.ts";
 import {
   ErrorHandler,
   Handler,
@@ -10,11 +9,11 @@ import {
   IslandModule,
   MiddlewareModule,
   RouteConfig,
-  ServeHandler,
   ServeHandlerInfo,
   StartOptions,
   UnknownHandler,
 } from "./types.ts";
+import { startFromContext } from "./boot.ts";
 export {
   defineApp,
   defineConfig,
@@ -112,67 +111,5 @@ export async function createHandler(
 
 export async function start(routes: Manifest, opts: StartOptions = {}) {
   const ctx = await ServerContext.fromManifest(routes, opts);
-
-  if (!opts.onListen) {
-    opts.onListen = (params) => {
-      console.log();
-      console.log(
-        colors.bgRgb8(colors.black(colors.bold(" 🍋 Fresh ready ")), 121),
-      );
-
-      const address = colors.cyan(`http://localhost:${params.port}/`);
-      const localLabel = colors.bold("Local:");
-      console.log(`    ${localLabel} ${address}\n`);
-    };
-  }
-
-  const portEnv = Deno.env.get("PORT");
-  if (portEnv !== undefined) {
-    opts.port ??= parseInt(portEnv, 10);
-  }
-
-  const handler = ctx.handler();
-
-  if (opts.port) {
-    await bootServer(handler, opts);
-  } else {
-    // No port specified, check for a free port. Instead of picking just
-    // any port we'll check if the next one is free for UX reasons.
-    // That way the user only needs to increment a number when running
-    // multiple apps vs having to remember completely different ports.
-    let firstError;
-    for (let port = 8000; port < 8020; port++) {
-      try {
-        await bootServer(handler, { ...opts, port });
-        firstError = undefined;
-        break;
-      } catch (err) {
-        if (err instanceof Deno.errors.AddrInUse) {
-          // Throw first EADDRINUSE error
-          // if no port is free
-          if (!firstError) {
-            firstError = err;
-          }
-          continue;
-        }
-
-        throw err;
-      }
-    }
-
-    if (firstError) {
-      throw firstError;
-    }
-  }
-}
-
-async function bootServer(handler: ServeHandler, opts: StartOptions) {
-  // @ts-ignore Ignore type error when type checking with Deno versions
-  if (typeof Deno.serve === "function") {
-    // @ts-ignore Ignore type error when type checking with Deno versions
-    await Deno.serve(opts, handler).finished;
-  } else {
-    // @ts-ignore Deprecated std serve way
-    await serve(handler, opts);
-  }
+  await startFromContext(ctx, opts);
 }


### PR DESCRIPTION
This PR changes the `dev.ts` script so that it doesn't import `main.ts` anymore if the new `config` parameter was passed. This changes the architecture in that the `dev` mode doesn't sit on top of `main` anymore which allows us to properly detect if we're in dev mode without other means. By calling into `ServerContext` directly instead of somewhere abstracted away behind `start` we can set all options ourselves, like if we want to skip loading the snapshot or not.

Note that this still preserves the previous behavior when no `fresh.config.ts` file is used. So this isn't a breaking change.

Fixes #1650