### PR TITLE
chore: Use `satisfies` instead of `as`

### DIFF
--- a/docs/latest/examples/migrating-to-tailwind.md
+++ b/docs/latest/examples/migrating-to-tailwind.md
@@ -18,7 +18,7 @@ export default {
   content: [
     "{routes,islands,components}/**/*.{ts,tsx}",
   ],
-} as Config;
+} satisfies Config;
 ```
 
 2. Create a css file in your static directory `<project>/static/styles.css`:

--- a/init.ts
+++ b/init.ts
@@ -306,7 +306,7 @@ export default {
   content: [
     "{routes,islands,components}/**/*.{ts,tsx}",
   ],
-} as Config;
+} satisfies Config;
 `;
 if (useTailwind) {
   await Deno.writeTextFile(

--- a/tests/fixture_tailwind/tailwind.config.ts
+++ b/tests/fixture_tailwind/tailwind.config.ts
@@ -4,4 +4,4 @@ export default {
   content: [
     "{routes,islands,components}/**/*.{ts,tsx}",
   ],
-} as Config;
+} satisfies Config;

--- a/tests/fixture_tailwind_build/tailwind.config.ts
+++ b/tests/fixture_tailwind_build/tailwind.config.ts
@@ -4,4 +4,4 @@ export default {
   content: [
     "{routes,islands,components}/**/*.{ts,tsx}",
   ],
-} as Config;
+} satisfies Config;

--- a/www/tailwind.config.ts
+++ b/www/tailwind.config.ts
@@ -18,4 +18,4 @@ export default {
       });
     }),
   ],
-} as Config;
+} satisfies Config;


### PR DESCRIPTION
Use `as`

<img width="590" alt="image" src="https://github.com/denoland/fresh/assets/359395/c803257f-fa95-47e0-80c4-5f050790667f">

Use `satisfies`

<img width="663" alt="image" src="https://github.com/denoland/fresh/assets/359395/e6913f05-e24b-4f51-b413-03c4c089f542">
