### PR TITLE
fix: route param fallback not empty string

### DIFF
--- a/src/server/router.ts
+++ b/src/server/router.ts
@@ -292,9 +292,7 @@ export function getParamsAndRoute(
         for (const key in matched) {
           const value = matched[key];
 
-          if (value !== undefined) {
-            groups[key] = decodeURIComponent(value);
-          }
+          groups[key] = value !== undefined ? decodeURIComponent(value) : "";
         }
         return {
           route: route,

--- a/tests/fixture/fresh.gen.ts
+++ b/tests/fixture/fresh.gen.ts
@@ -80,6 +80,7 @@ import * as $state_middleware_foo_middleware from "./routes/state-middleware/foo
 import * as $state_middleware_foo_index from "./routes/state-middleware/foo/index.tsx";
 import * as $static from "./routes/static.tsx";
 import * as $status_overwrite from "./routes/status_overwrite.tsx";
+import * as $std from "./routes/std.tsx";
 import * as $umlaut_äöüß from "./routes/umlaut-äöüß.tsx";
 import * as $wildcard from "./routes/wildcard.tsx";
 import * as $Counter from "./islands/Counter.tsx";
@@ -198,6 +199,7 @@ const manifest = {
     "./routes/state-middleware/foo/index.tsx": $state_middleware_foo_index,
     "./routes/static.tsx": $static,
     "./routes/status_overwrite.tsx": $status_overwrite,
+    "./routes/std.tsx": $std,
     "./routes/umlaut-äöüß.tsx": $umlaut_äöüß,
     "./routes/wildcard.tsx": $wildcard,
   },

--- a/tests/fixture/routes/std.tsx
+++ b/tests/fixture/routes/std.tsx
@@ -1,0 +1,9 @@
+import { PageProps, RouteConfig } from "$fresh/server.ts";
+
+export default function Page(props: PageProps) {
+  return <pre>{JSON.stringify(props.params, null, 2)}</pre>;
+}
+
+export const config: RouteConfig = {
+  routeOverride: "/std{@:version}?/:path*",
+};

--- a/tests/main_test.ts
+++ b/tests/main_test.ts
@@ -1212,3 +1212,11 @@ Deno.test("Expose config in ctx", async () => {
     });
   });
 });
+
+Deno.test("empty string fallback for optional params", async () => {
+  await withFakeServe("./tests/fixture/main.ts", async (server) => {
+    const doc = await server.getHtml(`/std/foo`);
+    const data = JSON.parse(doc.querySelector("pre")?.textContent!);
+    assertEquals(data, { path: "foo", version: "" });
+  });
+});


### PR DESCRIPTION
The `URLPattern` class always falls back to an empty string for optional groups, but regexes use `undefined`. This PR aligns the behaviour with `URLPattern`