### PR TITLE
Revert "chore: simplify deno check:types command"

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -5,7 +5,7 @@
     "fixture": "deno run -A --watch=static/,routes/ tests/fixture/dev.ts",
     "www": "deno task --cwd=www start",
     "screenshot": "deno run -A www/utils/screenshot.ts",
-    "check:types": "deno check **/*.ts **/*.tsx",
+    "check:types": "deno check **/*.ts && deno check **/*.tsx",
     "ok": "deno fmt --check && deno lint && deno task check:types && deno task test",
     "install-puppeteer": "PUPPETEER_PRODUCT=chrome deno run -A --unstable https://deno.land/x/puppeteer@16.2.0/install.ts && PUPPETEER_PRODUCT=firefox deno run -A --unstable https://deno.land/x/puppeteer@16.2.0/install.ts",
     "test:www": "deno test -A tests/www/",


### PR DESCRIPTION
Reverts denoland/fresh#2259
Windows is failing with this change:
* my PR https://github.com/denoland/fresh/actions/runs/7556810357/job/20574665605?pr=2261
* your PR https://github.com/denoland/fresh/actions/runs/7543217433/job/20533721591
* the commit from merging your PR https://github.com/denoland/fresh/actions/runs/7543221780/job/20533736560

```
Run deno task check:types
Task check:types deno check **/*.ts **/*.tsx
Error launching 'deno': The filename or extension is too long. (os error 206)
Error: Process completed with exit code 1.
```