### PR TITLE
fix: error when no `Response` instance is returned

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -295,10 +295,19 @@ export class App<State> {
       }
 
       try {
+        let result: unknown;
         if (handlers.length === 1 && handlers[0].length === 1) {
-          return handlers[0][0](ctx);
+          result = await handlers[0][0](ctx);
+        } else {
+          result = await runMiddlewares(handlers, ctx);
         }
-        return await runMiddlewares(handlers, ctx);
+        if (!(result instanceof Response)) {
+          throw new Error(
+            `Expected a "Response" instance to be returned, but got: ${result}`,
+          );
+        }
+
+        return result;
       } catch (err) {
         if (err instanceof HttpError) {
           if (err.status >= 500) {

--- a/src/app_test.tsx
+++ b/src/app_test.tsx
@@ -486,3 +486,18 @@ Deno.test("FreshApp - support setting request init in ctx.render()", async () =>
   expect(res.status).toEqual(416);
   expect(res.headers.get("X-Foo")).toEqual("foo");
 });
+
+Deno.test("FreshApp - throw when middleware returns no response", async () => {
+  const app = new App<{ text: string }>()
+    .get(
+      "/",
+      // deno-lint-ignore no-explicit-any
+      (() => {}) as any,
+    );
+
+  const server = new FakeServer(app.handler());
+  const res = await server.get("/");
+  const text = await res.text();
+  expect(res.status).toEqual(500);
+  expect(text).toContain("Internal server error");
+});


### PR DESCRIPTION
Fixes https://github.com/denoland/fresh/issues/1494