### PR TITLE
feat:use std lib to replace the custom processbar 

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -42,7 +42,7 @@
   },
   "imports": {
     "@deno/doc": "jsr:@deno/doc@^0.172.0",
-    "@std/cli": "jsr:@std/cli@^1.0.17",
+    "@std/cli": "jsr:@std/cli@^1.0.19",
     "@std/collections": "jsr:@std/collections@^1.0.11",
     "@std/http": "jsr:@std/http@^1.0.15",
     "@std/uuid": "jsr:@std/uuid@^1.0.7",

--- a/deno.lock
+++ b/deno.lock
@@ -19,7 +19,9 @@
     "jsr:@std/async@^1.0.13": "1.0.13",
     "jsr:@std/bytes@^1.0.2": "1.0.6",
     "jsr:@std/bytes@^1.0.5": "1.0.6",
+    "jsr:@std/cli@*": "1.0.17",
     "jsr:@std/cli@^1.0.17": "1.0.17",
+    "jsr:@std/cli@^1.0.19": "1.0.19",
     "jsr:@std/collections@^1.0.11": "1.1.0",
     "jsr:@std/crypto@1": "1.0.5",
     "jsr:@std/crypto@^1.0.4": "1.0.5",
@@ -30,6 +32,7 @@
     "jsr:@std/expect@^1.0.16": "1.0.16",
     "jsr:@std/fmt@1": "1.0.8",
     "jsr:@std/fmt@1.0.3": "1.0.3",
+    "jsr:@std/fmt@^1.0.2": "1.0.8",
     "jsr:@std/fmt@^1.0.3": "1.0.8",
     "jsr:@std/fmt@^1.0.7": "1.0.8",
     "jsr:@std/fmt@^1.0.8": "1.0.8",
@@ -48,6 +51,7 @@
     "jsr:@std/io@0.225.0": "0.225.0",
     "jsr:@std/json@^1.0.2": "1.0.2",
     "jsr:@std/jsonc@1": "1.0.2",
+    "jsr:@std/jsonc@^1.0.1": "1.0.2",
     "jsr:@std/media-types@1": "1.1.0",
     "jsr:@std/media-types@^1.1.0": "1.1.0",
     "jsr:@std/net@^1.0.4": "1.0.4",
@@ -148,7 +152,7 @@
         "jsr:@std/fs@1",
         "jsr:@std/html@1",
         "jsr:@std/http",
-        "jsr:@std/jsonc",
+        "jsr:@std/jsonc@1",
         "jsr:@std/media-types@1",
         "jsr:@std/path@1",
         "jsr:@std/semver",
@@ -204,6 +208,9 @@
     "@std/cli@1.0.17": {
       "integrity": "e15b9abe629e17be90cc6216327f03a29eae613365f1353837fa749aad29ce7b"
     },
+    "@std/cli@1.0.19": {
+      "integrity": "b3601a54891f89f3f738023af11960c4e6f7a45dc76cde39a6861124cba79e88"
+    },
     "@std/collections@1.1.0": {
       "integrity": "2ee8761c84c3d203f7a4ecd376f9ca88a0c559817a4a54c9150f28c0b948027c"
     },
@@ -248,7 +255,7 @@
     "@std/http@1.0.16": {
       "integrity": "80c8d08c4bfcf615b89978dcefb84f7e880087cf3b6b901703936f3592a06933",
       "dependencies": [
-        "jsr:@std/cli",
+        "jsr:@std/cli@^1.0.17",
         "jsr:@std/encoding@^1.0.10",
         "jsr:@std/fmt@^1.0.8",
         "jsr:@std/html@^1.0.4",
@@ -1875,7 +1882,7 @@
       "jsr:@luca/esbuild-deno-loader@0.11",
       "jsr:@marvinh-test/fresh-island@^0.0.1",
       "jsr:@std/async@^1.0.13",
-      "jsr:@std/cli@^1.0.17",
+      "jsr:@std/cli@^1.0.19",
       "jsr:@std/collections@^1.0.11",
       "jsr:@std/crypto@1",
       "jsr:@std/datetime@~0.225.2",

--- a/update/src/update.ts
+++ b/update/src/update.ts
@@ -2,6 +2,7 @@ import * as path from "@std/path";
 import * as JSONC from "@std/jsonc";
 import * as tsmorph from "ts-morph";
 import * as colors from "@std/fmt/colors";
+import { ProgressBar } from "@std/cli/unstable-progress-bar";
 
 export const SyntaxKind = tsmorph.ts.SyntaxKind;
 
@@ -15,17 +16,6 @@ export interface DenoJson {
   name?: string;
   version?: string;
   imports?: Record<string, string>;
-}
-
-// add a progress bar function
-function createProgressBar(current: number, total: number): string {
-  const percentage = Math.round((current / total) * 100);
-  const progressLength = 40;
-  const filled = Math.round((percentage / 100) * progressLength);
-  const empty = progressLength - filled;
-
-  const bar = "█".repeat(filled) + "░".repeat(empty);
-  return `[${bar}] ${percentage}% (${current}/${total})`;
 }
 
 async function format(filePath: string) {
@@ -175,7 +165,15 @@ export async function updateProject(dir: string) {
   let completedFiles = 0;
   const modifiedFilesList: string[] = [];
 
-  // process files sequentially to show proper pro
+  // Create a progress bar
+  const bar = new ProgressBar({
+    max: sfs.length,
+    fmt(x) {
+      return `[${x.styledTime}] [${x.progressBar}] [${x.value}/${x.max} files]`;
+    },
+  });
+
+  // process files sequentially to show proper progress
   await Promise.all(sfs.map(async (sourceFile) => {
     try {
       const wasModified = await updateFile(sourceFile);
@@ -190,18 +188,12 @@ export async function updateProject(dir: string) {
       throw err;
     } finally {
       completedFiles++;
-
-      // update progress bar
-      const progress = createProgressBar(completedFiles, sfs.length);
-      Deno.stdout.writeSync(
-        new TextEncoder().encode(`\r${colors.blue(progress)} Complete!`),
-      );
+      bar.value = completedFiles;
     }
   }));
 
-  // add completion log
-  // deno-lint-ignore no-console
-  console.log("");
+  // Clear the progress line and add a newline
+  await bar.stop();
 
   // add migration summary
   // deno-lint-ignore no-console


### PR DESCRIPTION
- The constructor of the process-bar in the currently used std/cli differs from that of the latest version, so the relevant dependencies have been updated.

- The custom processbar has been replaced with the std lib, and customization has been carried out to meet the current scenario.

In test env, seem like: 
![bb2868ed3911071ce9915a9c8662786](https://github.com/user-attachments/assets/e4419965-40fc-4ad8-8647-74e30c75ea98)

close #3021