### PR TITLE
fix: middleware regressions

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -418,7 +418,7 @@ export class App<State> {
       }
     }
 
-    const rootMiddlewares = this.#root.middlewares;
+    const rootMiddlewares = segmentToMiddlewares(this.#root);
 
     return async (
       req: Request,

--- a/src/router.ts
+++ b/src/router.ts
@@ -33,7 +33,6 @@ export interface Router<T> {
     method: Method | "OPTIONS" | "ALL",
     pathname: string,
     handlers: T[],
-    unshift?: boolean,
   ): void;
   match(method: Method, url: URL, init?: T[]): RouteResult<T>;
   getAllowedMethods(pattern: string): string[];
@@ -56,27 +55,17 @@ export class UrlPatternRouter<T> implements Router<T> {
   }
 
   add(
-    method: Method | "ALL",
+    method: Method,
     pathname: string,
     handlers: T[],
-    unshift = false,
   ) {
     let allowed = this.#allowed.get(pathname);
     if (allowed === undefined) {
       allowed = new Set();
       this.#allowed.set(pathname, allowed);
     }
-    if (method === "ALL") {
-      allowed.add("GET");
-      allowed.add("POST");
-      allowed.add("PATCH");
-      allowed.add("PUT");
-      allowed.add("DELETE");
-      allowed.add("HEAD");
-      allowed.add("OPTIONS");
-    } else {
-      allowed.add(method);
-    }
+
+    allowed.add(method);
 
     let byMethod: RouteByMethod<T>;
     if (IS_PATTERN.test(pathname)) {
@@ -120,18 +109,7 @@ export class UrlPatternRouter<T> implements Router<T> {
       byMethod = def.byMethod;
     }
 
-    const fn = unshift ? "unshift" : "push";
-    if (method === "ALL") {
-      byMethod.DELETE[fn](...handlers);
-      byMethod.GET[fn](...handlers);
-      byMethod.HEAD[fn](...handlers);
-      byMethod.OPTIONS[fn](...handlers);
-      byMethod.PATCH[fn](...handlers);
-      byMethod.POST[fn](...handlers);
-      byMethod.PUT[fn](...handlers);
-    } else {
-      byMethod[method][fn](...handlers);
-    }
+    byMethod[method].push(...handlers);
   }
 
   match(method: Method, url: URL, init: T[] = []): RouteResult<T> {

--- a/src/router.ts
+++ b/src/router.ts
@@ -21,6 +21,18 @@ export interface DynamicRouteDef<T> {
   byMethod: RouteByMethod<T>;
 }
 
+function newByMethod<T>(): RouteByMethod<T> {
+  return {
+    GET: [],
+    POST: [],
+    PATCH: [],
+    DELETE: [],
+    PUT: [],
+    HEAD: [],
+    OPTIONS: [],
+  };
+}
+
 export interface RouteResult<T> {
   params: Record<string, string>;
   handlers: T[];
@@ -73,15 +85,7 @@ export class UrlPatternRouter<T> implements Router<T> {
       if (def === undefined) {
         def = {
           pattern: new URLPattern({ pathname }),
-          byMethod: {
-            DELETE: [],
-            GET: [],
-            HEAD: [],
-            OPTIONS: [],
-            PATCH: [],
-            POST: [],
-            PUT: [],
-          },
+          byMethod: newByMethod(),
         };
         this.#dynamics.set(pathname, def);
         this.#dynamicArr.push(def);
@@ -93,15 +97,7 @@ export class UrlPatternRouter<T> implements Router<T> {
       if (def === undefined) {
         def = {
           pattern: pathname,
-          byMethod: {
-            DELETE: [],
-            GET: [],
-            HEAD: [],
-            OPTIONS: [],
-            PATCH: [],
-            POST: [],
-            PUT: [],
-          },
+          byMethod: newByMethod(),
         };
         this.#statics.set(pathname, def);
       }

--- a/tests/active_links_test.tsx
+++ b/tests/active_links_test.tsx
@@ -1,4 +1,4 @@
-import { App } from "fresh";
+import { App, staticFiles } from "fresh";
 import {
   allIslandApp,
   assertNotSelector,
@@ -27,7 +27,8 @@ function testApp<T>(): App<T> {
   const app = new App<T>()
     .island(selfCounter, "SelfCounter", SelfCounter)
     .island(partialInIsland, "PartialInIsland", PartialInIsland)
-    .island(jsonIsland, "JsonIsland", JsonIsland);
+    .island(jsonIsland, "JsonIsland", JsonIsland)
+    .use(staticFiles());
   setBuildCache(app, getBuildCache(allIslandApp));
   return app;
 }

--- a/tests/islands_test.tsx
+++ b/tests/islands_test.tsx
@@ -1,4 +1,4 @@
-import { App, fsRoutes } from "fresh";
+import { App, fsRoutes, staticFiles } from "fresh";
 import { Counter } from "./fixtures_islands/Counter.tsx";
 import { IslandInIsland } from "./fixtures_islands/IslandInIsland.tsx";
 import { JsonIsland } from "./fixtures_islands/JsonIsland.tsx";
@@ -37,6 +37,7 @@ await buildProd(allIslandApp);
 function testApp(config?: FreshConfig) {
   const app = new App(config);
   setBuildCache(app, getBuildCache(allIslandApp));
+  app.use(staticFiles());
   return app;
 }
 

--- a/tests/partials_test.tsx
+++ b/tests/partials_test.tsx
@@ -1,4 +1,4 @@
-import { App } from "fresh";
+import { App, staticFiles } from "fresh";
 import { Partial } from "fresh/runtime";
 import {
   allIslandApp,
@@ -40,7 +40,8 @@ function testApp<T>(): App<T> {
     .island(selfCounter, "SelfCounter", SelfCounter)
     .island(partialInIsland, "PartialInIsland", PartialInIsland)
     .island(jsonIsland, "JsonIsland", JsonIsland)
-    .island(optOutPartialLink, "OptOutPartialLink", OptOutPartialLink);
+    .island(optOutPartialLink, "OptOutPartialLink", OptOutPartialLink)
+    .use(staticFiles());
 
   setBuildCache(app, getBuildCache(allIslandApp));
   return app;

--- a/www/main.ts
+++ b/www/main.ts
@@ -1,6 +1,7 @@
-import { App, fsRoutes, trailingSlashes } from "fresh";
+import { App, fsRoutes, staticFiles, trailingSlashes } from "fresh";
 
 export const app = new App({ root: import.meta.url })
+  .use(staticFiles())
   .use(trailingSlashes("never"));
 
 await fsRoutes(app, {


### PR DESCRIPTION
Fixes some regressions found after merging https://github.com/denoland/fresh/pull/3086

- Missing 404 middlewares when mounting sub-apps
- revert more staticFiles logic to always require the middleware like before