### PR TITLE
chore: release 2.0.0-alpha.45

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -8,7 +8,7 @@
     "./www"
   ],
   "name": "@fresh/core",
-  "version": "2.0.0-alpha.44",
+  "version": "2.0.0-alpha.45",
   "license": "MIT",
   "exports": {
     ".": "./src/mod.ts",

--- a/init/deno.json
+++ b/init/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@fresh/init",
-  "version": "2.0.0-alpha.44",
+  "version": "2.0.0-alpha.45",
   "license": "MIT",
   "exports": "./src/mod.ts",
   "exclude": ["**/tmp/*"],

--- a/init/src/init.ts
+++ b/init/src/init.ts
@@ -3,7 +3,7 @@ import * as colors from "@std/fmt/colors";
 import * as path from "@std/path";
 
 // Keep these as is, as we replace these version in our release script
-const FRESH_VERSION = "2.0.0-alpha.44";
+const FRESH_VERSION = "2.0.0-alpha.45";
 const FRESH_TAILWIND_VERSION = "0.0.1-alpha.9";
 const PREACT_VERSION = "10.26.9";
 const PREACT_SIGNALS_VERSION = "2.2.1";

--- a/update/deno.json
+++ b/update/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@fresh/update",
-  "version": "2.0.0-alpha.44",
+  "version": "2.0.0-alpha.45",
   "license": "MIT",
   "exports": "./src/mod.ts",
   "exclude": ["**/tmp/*"],

--- a/update/src/update.ts
+++ b/update/src/update.ts
@@ -6,7 +6,7 @@ import { ProgressBar } from "@std/cli/unstable-progress-bar";
 
 export const SyntaxKind = tsmorph.ts.SyntaxKind;
 
-export const FRESH_VERSION = "2.0.0-alpha.44";
+export const FRESH_VERSION = "2.0.0-alpha.45";
 export const PREACT_VERSION = "10.26.9";
 export const PREACT_SIGNALS_VERSION = "2.2.1";
 


### PR DESCRIPTION
This is done to pick up the latest tailwind version in `@fresh/init`