### PR TITLE
feat: support setting production source maps on builder

### DIFF
--- a/docs/canary/concepts/builder.md
+++ b/docs/canary/concepts/builder.md
@@ -42,6 +42,13 @@ const builder = new Builder({
   routeDir?: string;
   // File paths which should be ignored 
   ignore?: RegExp[];
+  // Optionally generate production source maps
+  // See https://esbuild.github.io/api/#source-maps
+  sourceMap?: {
+    kind?: boolean | 'linked' | 'inline' | 'external' | 'both';
+    sourceRoot?: string;
+    sourcesContent?: boolean;
+  };
 })
 ```
 

--- a/src/dev/builder.ts
+++ b/src/dev/builder.ts
@@ -2,7 +2,7 @@ import { App, type ListenOptions, setBuildCache } from "../app.ts";
 import { fsAdapter } from "../fs.ts";
 import * as path from "@std/path";
 import * as colors from "@std/fmt/colors";
-import { bundleJs } from "./esbuild.ts";
+import { bundleJs, type FreshBundleOptions } from "./esbuild.ts";
 
 import { liveReload } from "./middlewares/live_reload.ts";
 import {
@@ -79,14 +79,21 @@ export interface BuildOptions {
    * File paths which should be ignored when crawling the file system.
    */
   ignore?: RegExp[];
+
+  /**
+   * Control if/how production source maps should be handled.
+   * See https://esbuild.github.io/api/#source-maps for more information.
+   */
+  sourceMap?: FreshBundleOptions["sourceMap"];
 }
 
 /**
  * The final resolved Builder configuration.
  */
-export type ResolvedBuildConfig = Required<BuildOptions> & {
+export type ResolvedBuildConfig = Required<Omit<BuildOptions, "sourceMap">> & {
   mode: "development" | "production";
   buildId: string;
+  sourceMap?: FreshBundleOptions["sourceMap"];
 };
 
 const TEST_FILE_PATTERN = /[._]test\.(?:[tj]sx?|[mc][tj]s)$/;
@@ -121,6 +128,7 @@ export class Builder<State = any> {
       ignore: options?.ignore ?? [TEST_FILE_PATTERN],
       mode: "production",
       buildId: BUILD_ID,
+      sourceMap: options?.sourceMap,
     };
   }
 
@@ -304,6 +312,7 @@ export class Builder<State = any> {
       entryPoints,
       jsxImportSource,
       denoJsonPath: denoJson,
+      sourceMap: this.config.sourceMap,
     });
 
     const prefix = `/_fresh/js/${BUILD_ID}/`;

--- a/src/dev/esbuild.ts
+++ b/src/dev/esbuild.ts
@@ -1,5 +1,5 @@
 import { denoPlugin } from "@deno/esbuild-plugin";
-import type { Plugin as EsbuildPlugin } from "esbuild";
+import type { BuildOptions, Plugin as EsbuildPlugin } from "esbuild";
 import * as path from "@std/path";
 
 export interface FreshBundleOptions {
@@ -11,6 +11,14 @@ export interface FreshBundleOptions {
   entryPoints: Record<string, string>;
   target: string | string[];
   jsxImportSource?: string;
+  sourceMap?: {
+    /** Documentation: https://esbuild.github.io/api/#sourcemap */
+    kind: BuildOptions["sourcemap"];
+    /** Documentation: https://esbuild.github.io/api/#source-root */
+    sourceRoot?: BuildOptions["sourceRoot"];
+    /** Documentation: https://esbuild.github.io/api/#sources-content */
+    sourcesContent?: BuildOptions["sourcesContent"];
+  };
 }
 
 export interface BuildOutput {
@@ -48,7 +56,9 @@ export async function bundleJs(
     bundle: true,
     splitting: true,
     treeShaking: true,
-    sourcemap: options.dev ? "linked" : false,
+    sourcemap: options.dev ? "linked" : options.sourceMap?.kind,
+    sourceRoot: options.dev ? undefined : options.sourceMap?.sourceRoot,
+    sourcesContent: options.dev ? undefined : options.sourceMap?.sourcesContent,
     minify: !options.dev,
     logOverride: {
       "suspicious-nullish-coalescing": "silent",


### PR DESCRIPTION
This adds a new `sourceMap` option on the `Builder` configuration. This can be used to optionally specify how production source maps should be generated.

See https://esbuild.github.io/api/#source-maps for more information.