### PR TITLE
feat: allow importing runtime exports from core

### DIFF
--- a/packages/fresh/src/context_test.tsx
+++ b/packages/fresh/src/context_test.tsx
@@ -1,7 +1,6 @@
 import { expect } from "@std/expect";
 import { Context } from "./context.ts";
-import { App } from "fresh";
-import { asset } from "fresh/runtime";
+import { App, asset } from "fresh";
 import { FakeServer } from "./test_utils.ts";
 import { BUILD_ID } from "@fresh/build-id";
 import { parseHtml } from "../tests/test_utils.tsx";

--- a/packages/fresh/src/mod.ts
+++ b/packages/fresh/src/mod.ts
@@ -1,3 +1,10 @@
+export {
+  asset,
+  assetSrcSet,
+  IS_BROWSER,
+  Partial,
+  type PartialProps,
+} from "@fresh/core/runtime";
 export { App, type ListenOptions } from "./app.ts";
 export { trailingSlashes } from "./middlewares/trailing_slashes.ts";
 export {

--- a/packages/fresh/tests/active_links_test.tsx
+++ b/packages/fresh/tests/active_links_test.tsx
@@ -1,4 +1,4 @@
-import { App, staticFiles } from "fresh";
+import { App, Partial, staticFiles } from "fresh";
 import {
   ALL_ISLAND_DIR,
   assertNotSelector,
@@ -10,7 +10,6 @@ import {
 } from "./test_utils.tsx";
 
 import { FakeServer } from "../src/test_utils.ts";
-import { Partial } from "fresh/runtime";
 
 const allIslandCache = await buildProd({ islandDir: ALL_ISLAND_DIR });
 

--- a/packages/fresh/tests/partials_test.tsx
+++ b/packages/fresh/tests/partials_test.tsx
@@ -1,5 +1,4 @@
-import { App, staticFiles } from "fresh";
-import { Partial } from "fresh/runtime";
+import { App, Partial, staticFiles } from "fresh";
 import {
   ALL_ISLAND_DIR,
   assertMetaContent,

--- a/www/routes/docs/[...slug].tsx
+++ b/www/routes/docs/[...slug].tsx
@@ -1,5 +1,4 @@
-import { HttpError, page } from "fresh";
-import { asset, Partial } from "fresh/runtime";
+import { asset, HttpError, page, Partial } from "fresh";
 import { SidebarCategory } from "../../components/DocsSidebar.tsx";
 import Footer from "../../components/Footer.tsx";
 import Header from "../../components/Header.tsx";

--- a/www/routes/index.tsx
+++ b/www/routes/index.tsx
@@ -1,5 +1,4 @@
-import { asset } from "fresh/runtime";
-import { page } from "fresh";
+import { asset, page } from "fresh";
 import VERSIONS from "../../versions.json" with { type: "json" };
 import Footer from "../components/Footer.tsx";
 import Header from "../components/Header.tsx";

--- a/www/routes/recipes/lemon-honey-tea.tsx
+++ b/www/routes/recipes/lemon-honey-tea.tsx
@@ -1,5 +1,4 @@
-import { Partial } from "fresh/runtime";
-import type { RouteConfig } from "fresh";
+import { Partial, type RouteConfig } from "fresh";
 
 export const config: RouteConfig = {
   skipAppWrapper: true,

--- a/www/routes/recipes/lemonade.tsx
+++ b/www/routes/recipes/lemonade.tsx
@@ -1,5 +1,4 @@
-import { Partial } from "fresh/runtime";
-import type { RouteConfig } from "fresh";
+import { Partial, type RouteConfig } from "fresh";
 
 export const config: RouteConfig = {
   skipAppWrapper: true,

--- a/www/routes/recipes/lemondrop.tsx
+++ b/www/routes/recipes/lemondrop.tsx
@@ -1,5 +1,4 @@
-import { Partial } from "fresh/runtime";
-import type { RouteConfig } from "fresh";
+import { Partial, type RouteConfig } from "fresh";
 
 export const config: RouteConfig = {
   skipAppWrapper: true,

--- a/www/routes/showcase-bak.tsx
+++ b/www/routes/showcase-bak.tsx
@@ -1,5 +1,4 @@
-import { asset } from "fresh/runtime";
-import { page } from "fresh";
+import { asset, page } from "fresh";
 import Projects, { type Project } from "../components/Projects.tsx";
 import Header from "../components/Header.tsx";
 import Footer from "../components/Footer.tsx";

--- a/www/routes/showcase.tsx
+++ b/www/routes/showcase.tsx
@@ -1,5 +1,4 @@
-import { asset } from "fresh/runtime";
-import { page } from "fresh";
+import { asset, page } from "fresh";
 import Projects, { type Project } from "../components/Projects.tsx";
 import Header from "../components/Header.tsx";
 import Footer from "../components/Footer.tsx";

--- a/www/utils/markdown.ts
+++ b/www/utils/markdown.ts
@@ -1,8 +1,7 @@
 export { extractYaml as frontMatter } from "@std/front-matter";
 
 import * as Marked from "marked";
-import { HttpError } from "fresh";
-import { asset } from "fresh/runtime";
+import { asset, HttpError } from "fresh";
 import { escape as escapeHtml } from "@std/html";
 import { mangle } from "marked-mangle";
 import GitHubSlugger from "github-slugger";


### PR DESCRIPTION
This is just a potential suggestion, but I think it can be nice to just need `"fresh"` to import anything needed on the server. Currently, there may be multiple import statements (`"fresh"` + `"fresh/runtime"`) to get simple things from Fresh, e.g.:

```ts
import { page } from "fresh";
import { asset } from "fresh/runtime";
```

Given that [the `@fresh/core` package already imports from `@fresh/core/runtime`](https://github.com/denoland/fresh/blob/main/src/app.ts#L3), I don't think this should be a regression for existing code or esbuild.

```mermaid
graph TD;
    fresh <--> Server;
    fresh/runtime <--> Server;
    fresh/runtime <--> Browser["Browser (Islands)"];
```

Though I don't know if there is a desire to avoid exports existing from multiple entrypoints, or if there is some reason JSR prevents publishing like this.