### PR TITLE
fix!: rename the _fresh build folder to .fresh (BREAKING)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,4 +34,4 @@ jobs:
         with:
           project: "fresh"
           entrypoint: "server.js"
-          root: "./www/_fresh/"
+          root: "./www/.fresh/"

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-_fresh/
+.fresh/
 .vite/
 vendor/
 node_modules/

--- a/deno.json
+++ b/deno.json
@@ -19,7 +19,7 @@
     "release": "deno run -A tools/release.ts"
   },
   "exclude": [
-    "**/_fresh/*",
+    "**/.fresh/*",
     "**/tmp/*",
     "*/tests_OLD/**",
     "**/vite.config.ts.*",

--- a/docs/latest/advanced/builder.md
+++ b/docs/latest/advanced/builder.md
@@ -38,7 +38,7 @@ const builder = new Builder({
   // The path to your server entry point. (Default: `<root>/main.ts`)
   serverEntry?: string;
   // Where to write generated files when doing a production build.
-  // (default: `<root>/_fresh/`)
+  // (default: `<root>/.fresh/`)
   outDir?: string;
   // Path to static file directory. (Default: `<root>/static/`)
   staticDir?: string;

--- a/docs/latest/deployment/deno-compile.md
+++ b/docs/latest/deployment/deno-compile.md
@@ -11,7 +11,7 @@ platform without requiring Deno to be installed.
 # Build your app first
 $ deno task build
 # Generate self-contained executable
-deno compile --include static --include _fresh --include deno.json -A my-app _fresh/compiled-entry.js
+deno compile --include static --include .fresh --include deno.json -A my-app .fresh/compiled-entry.js
 ```
 
 The compiled entry supports two environment variables out of the box:

--- a/docs/latest/deployment/docker.md
+++ b/docs/latest/deployment/docker.md
@@ -25,11 +25,11 @@ WORKDIR /app
 
 COPY . .
 RUN deno task build
-RUN deno cache _fresh/server.js
+RUN deno cache .fresh/server.js
 
 EXPOSE 8000
 
-CMD ["serve", "-A", "_fresh/server.js"]
+CMD ["serve", "-A", ".fresh/server.js"]
 ```
 
 To build your Docker image inside of a Git repository:

--- a/docs/latest/deployment/index.md
+++ b/docs/latest/deployment/index.md
@@ -11,15 +11,15 @@ deno task build
 deno run -A dev.ts build
 ```
 
-Once completed, it will have created a `_fresh` folder in the project directory
+Once completed, it will have created a `.fresh` folder in the project directory
 which contains the optimized assets.
 
-> [info]: The `_fresh` folder should not be committed to git. Exclude it via
+> [info]: The `.fresh` folder should not be committed to git. Exclude it via
 > `.gitignore`.
 >
 > ```gitignore .gitignore
 > # Ignore fresh build directory
-> _fresh/
+> .fresh/
 > ```
 
 ## Running a production build
@@ -29,7 +29,7 @@ To run Fresh in production mode, run the `start` task:
 ```sh Terminal
 deno task start
 # or
-deno serve -A _fresh/server.js
+deno serve -A .fresh/server.js
 ```
 
-Fresh will automatically pick up the optimized assets in the `_fresh` directory.
+Fresh will automatically pick up the optimized assets in the `.fresh` directory.

--- a/docs/latest/examples/migration-guide.md
+++ b/docs/latest/examples/migration-guide.md
@@ -136,7 +136,7 @@ To launch Fresh in production mode:
 
 ```diff
 - deno run -A main.ts
-+ deno serve -A _fresh/server.js
++ deno serve -A .fresh/server.js
 ```
 
 You'll likely have that command inside your `deno.json` as a task. Update it
@@ -150,7 +150,7 @@ accordingly.
 -     "preview": "deno run -A main.ts"
 +     "dev": "vite",
 +     "build": "vite build",
-+     "preview": "deno serve -A _fresh/server.js"
++     "preview": "deno serve -A .fresh/server.js"
    }
   }
 ```

--- a/docs/latest/testing/index.md
+++ b/docs/latest/testing/index.md
@@ -123,7 +123,7 @@ const builder = await createBuilder({
 });
 await builder.build();
 
-const { app } = await import("./path/to/app/_fresh/server.js");
+const { app } = await import("./path/to/app/.fresh/server.js");
 
 Deno.test("My Test", async () => {
   const handler = app.handler();

--- a/packages/fresh/src/app.ts
+++ b/packages/fresh/src/app.ts
@@ -362,7 +362,7 @@ export class App<State> {
         DENO_DEPLOYMENT_ID !== undefined
       ) {
         throw new Error(
-          `Could not find _fresh directory. Maybe you forgot to run "deno task build"?`,
+          `Could not find .fresh directory. Maybe you forgot to run "deno task build"?`,
         );
       } else {
         buildCache = new MockBuildCache([], this.config.mode);

--- a/packages/fresh/src/dev/builder.ts
+++ b/packages/fresh/src/dev/builder.ts
@@ -48,7 +48,7 @@ export interface BuildOptions {
    *
    * This can be an absolute path, a file URL or a relative path.
    * Relative paths are resolved against the `root` option.
-   * @default "_fresh"
+   * @default ".fresh"
    */
   outDir?: string;
   /**
@@ -118,7 +118,7 @@ export class Builder<State = any> {
   constructor(options?: BuildOptions) {
     const root = parseDirPath(options?.root ?? ".", Deno.cwd());
     const serverEntry = parseDirPath(options?.serverEntry ?? "main.ts", root);
-    const outDir = parseDirPath(options?.outDir ?? "_fresh", root);
+    const outDir = parseDirPath(options?.outDir ?? ".fresh", root);
     const staticDir = parseDirPath(options?.staticDir ?? "static", root);
     const islandDir = parseDirPath(options?.islandDir ?? "islands", root);
     const routeDir = parseDirPath(options?.routeDir ?? "routes", root);

--- a/packages/fresh/src/dev/builder_test.ts
+++ b/packages/fresh/src/dev/builder_test.ts
@@ -489,7 +489,7 @@ export const app = new App()
     await new Builder({ root: tmp }).build();
 
     await withChildProcessServer(
-      { cwd: tmp, args: ["serve", "-A", "_fresh/server.js"] },
+      { cwd: tmp, args: ["serve", "-A", ".fresh/server.js"] },
       async (address) => {
         let res = await fetch(`${address}/foo.txt`);
         expect(await res.text()).toEqual("ok");
@@ -519,7 +519,7 @@ export const app = new App()
     await new Builder({ root: tmp, serverEntry: "other.ts" }).build();
 
     await withChildProcessServer(
-      { cwd: tmp, args: ["serve", "-A", "--port=0", "_fresh/server.js"] },
+      { cwd: tmp, args: ["serve", "-A", "--port=0", ".fresh/server.js"] },
       async (address) => {
         const res = await fetch(`${address}`);
         expect(await res.text()).toEqual("ok");
@@ -714,10 +714,10 @@ export const app = new App()
         "--include",
         "static/",
         "--include",
-        "_fresh",
+        ".fresh",
         "--output",
         outBin,
-        path.join("_fresh", "compiled-entry.js"),
+        path.join(".fresh", "compiled-entry.js"),
       ],
       cwd: tmp,
     }).output();

--- a/packages/init/src/init.ts
+++ b/packages/init/src/init.ts
@@ -148,7 +148,7 @@ export async function initProject(
 .env.local
 
 # Fresh build directory
-_fresh/
+.fresh/
 # npm + other dependencies
 node_modules/
 vendor/
@@ -167,11 +167,11 @@ ENV DENO_DEPLOYMENT_ID=\${GIT_REVISION}
 WORKDIR /app
 
 COPY . .
-RUN deno cache _fresh/server.js
+RUN deno cache .fresh/server.js
 
 EXPOSE 8000
 
-CMD ["serve", "-A", "_fresh/server.js"]
+CMD ["serve", "-A", ".fresh/server.js"]
 
 `;
     await writeFile("Dockerfile", DOCKERFILE_TEXT);
@@ -543,7 +543,7 @@ if (Deno.args.includes("build")) {
       check: "deno fmt --check . && deno lint . && deno check",
       dev: "deno run -A --watch=static/,routes/ dev.ts",
       build: "deno run -A dev.ts build",
-      start: "deno serve -A _fresh/server.js",
+      start: "deno serve -A .fresh/server.js",
       update: "deno run -A -r jsr:@fresh/update .",
     },
     lint: {
@@ -551,7 +551,7 @@ if (Deno.args.includes("build")) {
         tags: ["fresh", "recommended"],
       },
     },
-    exclude: ["**/_fresh/*"],
+    exclude: ["**/.fresh/*"],
     imports: {
       "fresh": `jsr:@fresh/core@^${freshVersion}`,
       "preact": `npm:preact@^${PREACT_VERSION}`,

--- a/packages/plugin-vite/deno.json
+++ b/packages/plugin-vite/deno.json
@@ -17,7 +17,7 @@
     "demo": "vite demo",
     "debug": "deno run -A --inspect-brk npm:vite demo",
     "demo:build": "vite build demo",
-    "demo:start": "cd demo && deno serve -A _fresh/server.js"
+    "demo:start": "cd demo && deno serve -A .fresh/server.js"
   },
   "imports": {
     "@babel/core": "npm:@babel/core@^7.28.0",

--- a/packages/plugin-vite/src/mod.ts
+++ b/packages/plugin-vite/src/mod.ts
@@ -99,7 +99,7 @@ export function fresh(config?: FreshViteConfig): Plugin[] {
                 manifest: true,
 
                 outDir: config.environments?.client?.build?.outDir ??
-                  "_fresh/client",
+                  ".fresh/client",
                 rollupOptions: {
                   preserveEntrySignatures: "strict",
                   input: {
@@ -116,7 +116,7 @@ export function fresh(config?: FreshViteConfig): Plugin[] {
                 copyPublicDir: false,
 
                 outDir: config.environments?.ssr?.build?.outDir ??
-                  "_fresh/server",
+                  ".fresh/server",
                 rollupOptions: {
                   onwarn(warning, handler) {
                     // Ignore "use client"; warnings

--- a/packages/plugin-vite/tests/build_test.ts
+++ b/packages/plugin-vite/tests/build_test.ts
@@ -455,7 +455,7 @@ Deno.test({
 
     // Read the generated server.js to check asset paths
     const serverJs = await Deno.readTextFile(
-      path.join(res.tmp, "_fresh", "server.js"),
+      path.join(res.tmp, ".fresh", "server.js"),
     );
 
     // Asset paths should include the base path /my-app/

--- a/packages/plugin-vite/tests/test_utils.ts
+++ b/packages/plugin-vite/tests/test_utils.ts
@@ -26,7 +26,9 @@ async function copyDir(from: string, to: string) {
   const entries = walk(from, {
     includeFiles: true,
     includeDirs: false,
-    skip: [/([\\/]+(_fresh|node_modules|vendor)[\\/]+|[\\/]+vite\.config\.ts)/],
+    skip: [
+      /([\\/]+(\.fresh|node_modules|vendor)[\\/]+|[\\/]+vite\.config\.ts)/,
+    ],
   });
 
   for await (const entry of entries) {
@@ -150,12 +152,12 @@ export async function buildVite(
     environments: {
       ssr: {
         build: {
-          outDir: path.join(tmp.dir, "_fresh", "server"),
+          outDir: path.join(tmp.dir, ".fresh", "server"),
         },
       },
       client: {
         build: {
-          outDir: path.join(tmp.dir, "_fresh", "client"),
+          outDir: path.join(tmp.dir, ".fresh", "client"),
         },
       },
     },
@@ -199,7 +201,7 @@ export async function launchProd(
     {
       cwd: options.cwd,
       args: options.args ??
-        ["serve", "-A", "--cached-only", "--port", "0", "_fresh/server.js"],
+        ["serve", "-A", "--cached-only", "--port", "0", ".fresh/server.js"],
     },
     fn,
   );

--- a/packages/update/src/update.ts
+++ b/packages/update/src/update.ts
@@ -137,8 +137,11 @@ export async function updateProject(dir: string) {
         tasks.check = "deno fmt --check && deno lint && deno check";
       }
 
-      if (tasks.preview === "deno run -A main.ts") {
-        tasks.preview = "deno serve -A _fresh/server.js";
+      if (
+        tasks.preview === "deno run -A main.ts" ||
+        tasks.preview === "deno serve -A _fresh/server.js"
+      ) {
+        tasks.preview = "deno serve -A .fresh/server.js";
       }
     }
   });

--- a/packages/update/src/update_test.ts
+++ b/packages/update/src/update_test.ts
@@ -116,7 +116,7 @@ Deno.test("update - 1.x project deno.json tasks + lock", async () => {
     .toEqual({
       build: "deno run -A dev.ts build",
       check: "deno fmt --check && deno lint && deno check",
-      preview: "deno serve -A _fresh/server.js",
+      preview: "deno serve -A .fresh/server.js",
       start: "deno run -A --watch=static/,routes/ dev.ts",
       update: "deno run -A -r jsr:@fresh/update .",
     });

--- a/www/deno.json
+++ b/www/deno.json
@@ -1,6 +1,6 @@
 {
   "tasks": {
-    "start": "deno serve -A _fresh/server.js",
+    "start": "deno serve -A .fresh/server.js",
     "dev": "vite",
     "build": "vite build"
   },

--- a/www/main_test.ts
+++ b/www/main_test.ts
@@ -12,7 +12,7 @@ Deno.test("CORS should not set on GET /fresh-badge.svg", async () => {
   await withChildProcessServer(
     {
       cwd: result.tmp,
-      args: ["serve", "-A", "--port", "0", "_fresh/server.js"],
+      args: ["serve", "-A", "--port", "0", ".fresh/server.js"],
     },
     async (address) => {
       const resp = await fetch(`${address}/fresh-badge.svg`);
@@ -29,7 +29,7 @@ Deno.test({
       await withChildProcessServer(
         {
           cwd: result.tmp,
-          args: ["serve", "-A", "--port", "0", "_fresh/server.js"],
+          args: ["serve", "-A", "--port", "0", ".fresh/server.js"],
         },
         async (address) => {
           await withBrowser(async (page) => {


### PR DESCRIPTION
As [mentioned in a prior discussion](https://github.com/denoland/fresh/pull/3122#discussion_r2226988418), it seemed like renaming `_fresh` build folder to `.fresh` would align more with generated files than the current `_`. This PR implements that suggestion, to make the breaking change potentially sooner rather than later.

### Prior arts

- `node_modules/.deno` - Deno installed packages
- `.vite` - Cache of prebuilt packages and files
- `.angular` - Cache of built files and metadata
- `.github/` or `.vscode/` folders

The `.` prefix in general seems to be used either for generated files, files that should be considered "hidden", or configuration files (e.g. `.editorconfig` or `.gitignore`). This seems to fit well with `outDir`, and would make naming more consistent IMO.