### PR TITLE
test: improve temp dir disposal for CI vs Local

### DIFF
--- a/packages/fresh/src/test_utils.ts
+++ b/packages/fresh/src/test_utils.ts
@@ -137,10 +137,15 @@ export async function withTmpDir(
   return {
     dir,
     async [Symbol.asyncDispose]() {
+      // Skip pointless cleanup in CI, speed up tests
+      if (Deno.env.get("CI") === "true") return;
+
       try {
         await Deno.remove(dir, { recursive: true });
       } catch {
-        // Ignore errors Files in tmp will be cleaned up by the OS
+        // Temp files are not cleaned up automatically on Windows
+        // deno-lint-ignore no-console
+        console.warn(`Failed to clean up temp dir: "${dir}"`);
       }
     },
   };


### PR DESCRIPTION
- Cleaning up TMP files in CI is unnecessary, as files are discarded automatically between runs (except of using cache/artifacts)
- On Windows, `<user>\AppData\Local\Temp\*` files are _not_ automatically removed (see resources below)

This PR should make tests a tiny bit faster in CI by avoiding work, as well as skipping error messages that might follow.

And running tests locally will now log warnings if temp files fails to be removed instead of silently continuing.

## Resources

- https://www.reddit.com/r/windows/comments/yfpbb1/why_arent_windows_temp_files_deleted/
- https://www.reddit.com/r/WindowsHelp/comments/1f4lgui/why_does_windows_cleanup_miss_temp_folder/?utm_source=chatgpt.com

<img width="1066" height="1065" alt="image" src="https://github.com/user-attachments/assets/55c98f86-e134-4a2d-86cc-cbab63048c47" />

Partially replaces #2990