### PR TITLE
fix: apply basePath correctly in dev mode for root index

### DIFF
--- a/packages/fresh/src/app.ts
+++ b/packages/fresh/src/app.ts
@@ -72,7 +72,7 @@ export type ListenOptions =
   & {
     remoteAddress?: string;
   };
-function createOnListen(
+export function createOnListen(
   basePath: string,
   options: ListenOptions,
 ): (localAddr: Deno.NetAddr) => void {

--- a/packages/fresh/src/dev/builder.ts
+++ b/packages/fresh/src/dev/builder.ts
@@ -1,4 +1,9 @@
-import { App, type ListenOptions, setBuildCache } from "../app.ts";
+import {
+  App,
+  createOnListen,
+  type ListenOptions,
+  setBuildCache,
+} from "../app.ts";
 import { fsAdapter } from "../fs.ts";
 import * as path from "@std/path";
 import * as colors from "@std/fmt/colors";
@@ -181,7 +186,11 @@ export class Builder<State = any> {
 
     const appHandler = app.handler();
 
-    const devApp = new App<State>(app.config)
+    // Store original basePath for display purposes
+    const originalBasePath = app.config.basePath;
+
+    const devConfig = { ...app.config, basePath: "" };
+    const devApp = new App<State>(devConfig)
       .use(liveReload())
       .use(devErrorOverlay())
       .use(automaticWorkspaceFolders(this.config.root))
@@ -200,7 +209,11 @@ export class Builder<State = any> {
     // Boot in parallel to spin up the server quicker. We'll hold
     // requests until the required assets are processed.
     await Promise.all([
-      devApp.listen(options),
+      devApp.listen({
+        ...options,
+        onListen: options.onListen ??
+          createOnListen(originalBasePath, options),
+      }),
       this.#build(buildCache, true),
     ]);
     return;

--- a/packages/fresh/src/dev/builder_test.ts
+++ b/packages/fresh/src/dev/builder_test.ts
@@ -433,7 +433,7 @@ Deno.test({
     const tmp = _tmp.dir;
 
     const app = new App({ basePath: "/foo/bar" })
-      .get("/", () => new Response("ok"))
+      .get("/", () => new Response("root index"))
       .get("/asdf", () => new Response("ok"));
 
     const builder = new Builder({
@@ -450,10 +450,20 @@ Deno.test({
       },
     });
 
-    const res = await fetch(`${address}/foo/bar/asdf`);
+    // Test regular route
+    const res1 = await fetch(`${address}/foo/bar/asdf`);
+    const text1 = await res1.text();
+    expect(text1).toEqual("ok");
 
-    const text = await res.text();
-    expect(text).toEqual("ok");
+    // Test root index with basePath (without trailing slash)
+    // This was the main issue - accessing /foo/bar should work
+    const res2 = await fetch(`${address}/foo/bar`);
+    const text2 = await res2.text();
+    expect(res2.status).toEqual(200);
+    expect(text2).toEqual("root index");
+
+    // Verify original app config is not mutated by dev builder
+    expect(app.config.basePath).toEqual("/foo/bar");
 
     controller.abort();
   },


### PR DESCRIPTION
## Summary
- Fixed an issue where basePath was not correctly applied in dev mode for the root index route
- The dev server now uses root path "/" while preserving the configured basePath for the main app

## Test plan 
- [x] Test that routes work correctly with basePath in dev mode
- [x] Verify root index route loads properly with basePath configuration
- [x] Ensure no regression in normal dev mode without basePath
- [x] Ran `deno task ok` - all tests pass except one unrelated vite dev test that appears to be flaky