### PR TITLE
fix: account for JS syntax when generating island names

### DIFF
--- a/packages/fresh/src/utils.ts
+++ b/packages/fresh/src/utils.ts
@@ -54,6 +54,15 @@ export class UniqueNamer {
   #seen = new Map<string, number>();
 
   getUniqueName(name: string): string {
+    // These names are only internal, so we can convert everything to
+    // plain ASCII.
+    name = name.replaceAll(/([^A-Za-z0-9_$]+)/g, "_");
+
+    // Identifiers must not start with a number
+    if (/^\d/.test(name) || JS_RESERVED.has(name)) {
+      name = "_" + name;
+    }
+
     const count = this.#seen.get(name);
     if (count === undefined) {
       this.#seen.set(name, 1);
@@ -65,6 +74,80 @@ export class UniqueNamer {
     return name;
   }
 }
+
+// See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#reserved_words
+const JS_RESERVED = new Set([
+  "break",
+  "case",
+  "catch",
+  "class",
+  "const",
+  "continue",
+  "debugger",
+  "default",
+  "delete",
+  "do",
+  "else",
+  "export",
+  "extends",
+  "false",
+  "finally",
+  "for",
+  "function",
+  "if",
+  "import",
+  "in",
+  "instanceof",
+  "new",
+  "null",
+  "return",
+  "super",
+  "switch",
+  "this",
+  "throw",
+  "true",
+  "try",
+  "typeof",
+  "var",
+  "void",
+  "while",
+  "with",
+  "let",
+  "static",
+  "yield",
+  "await",
+  "enum",
+  "implements",
+  "interface",
+  "package",
+  "private",
+  "protected",
+  "public",
+  "abstract",
+  "boolean",
+  "byte",
+  "char",
+  "double",
+  "final",
+  "float",
+  "goto",
+  "int",
+  "long",
+  "native",
+  "short",
+  "synchronized",
+  "throws",
+  "transient",
+  "volatile",
+  "arguments",
+  "as",
+  "async",
+  "eval",
+  "from",
+  "get",
+  "of",
+  "set",
+]);
 
 const PATH_TO_SPEC = /[\\/]+/g;
 export function pathToSpec(outDir: string, spec: string): string {

--- a/packages/fresh/src/utils_test.ts
+++ b/packages/fresh/src/utils_test.ts
@@ -1,5 +1,10 @@
 import { expect } from "@std/expect";
-import { escapeScript, pathToExportName, pathToSpec } from "./utils.ts";
+import {
+  escapeScript,
+  pathToExportName,
+  pathToSpec,
+  UniqueNamer,
+} from "./utils.ts";
 
 Deno.test("filenameToExportName", () => {
   expect(pathToExportName("/islands/foo.tsx")).toBe("foo");
@@ -66,4 +71,19 @@ Deno.test("pathToSpec", () => {
     "https://example.com",
   );
   expect(pathToSpec("/foo", "jsr:@foo/bar")).toEqual("jsr:@foo/bar");
+});
+
+Deno.test("UniqueNamer - generates unique name for same names", () => {
+  const namer = new UniqueNamer();
+  expect(namer.getUniqueName("foo")).toEqual("foo");
+  expect(namer.getUniqueName("foo")).toEqual("foo_1");
+});
+
+Deno.test("UniqueNamer - accounts for JS syntax", () => {
+  const namer = new UniqueNamer();
+  expect(namer.getUniqueName("foo-bar")).toEqual("foo_bar");
+  expect(namer.getUniqueName("switch")).toEqual("_switch");
+  expect(namer.getUniqueName("for")).toEqual("_for");
+  expect(namer.getUniqueName("0foo")).toEqual("_0foo");
+  expect(namer.getUniqueName("0foo$_🔥")).toEqual("_0foo$__");
 });


### PR DESCRIPTION
Fixes https://github.com/denoland/fresh/issues/3339