### PR TITLE
fix(vite): exclude packages from deno cache

### DIFF
--- a/packages/plugin-vite/src/mod.ts
+++ b/packages/plugin-vite/src/mod.ts
@@ -174,7 +174,7 @@ export function fresh(config?: FreshViteConfig): Plugin[] {
     ...devServer(),
     prefresh({
       include: [/\.[cm]?[tj]sx?$/],
-      exclude: [/node_modules/],
+      exclude: [/node_modules/, /\/deno\/npm\//],
       parserPlugins: [
         "importMeta",
         "explicitResourceManagement",

--- a/packages/plugin-vite/src/mod.ts
+++ b/packages/plugin-vite/src/mod.ts
@@ -174,7 +174,7 @@ export function fresh(config?: FreshViteConfig): Plugin[] {
     ...devServer(),
     prefresh({
       include: [/\.[cm]?[tj]sx?$/],
-      exclude: [/node_modules/, /\/deno\/npm\//],
+      exclude: [/node_modules/, /[\\/]+deno[\\/]+npm[\\/]+/],
       parserPlugins: [
         "importMeta",
         "explicitResourceManagement",


### PR DESCRIPTION
When disabling `node_modules` directory in Deno, prefresh plugin transforms files in ~/.cache/deno/npm/registry.npmjs.org/ directory, causing an arcane error to occur: https://github.com/preactjs/prefresh/issues/124

After disabling this transform my site now works on updated fresh version

I'm not sure if is the correct way to exclude this, but I don't see any longer pattern that would work here

The cache is stored in $XDG_CACHE_HOME/deno/npm/$REGISTRY_HOST, where only deno/npm part seems to be static