### PR TITLE
fix: avoid showing "Copied" if copying fails

### DIFF
--- a/www/assets/styles.css
+++ b/www/assets/styles.css
@@ -94,16 +94,7 @@ html[data-theme="dark"] ::selection {
   background-repeat: no-repeat;
 }
 
-.group:not([data-copied]) .group-not-copied {
-  display: block;
-}
-.group[data-copied] .group-not-copied {
-  display: none;
-}
-
-.group[data-copied] .group-copied {
-  display: block;
-}
+.group[data-copied] .group-not-copied,
 .group:not([data-copied]) .group-copied {
   display: none;
 }

--- a/www/client.ts
+++ b/www/client.ts
@@ -11,14 +11,14 @@ document.addEventListener("click", async (ev) => {
   const code = el.dataset.code;
   if (!code) return;
 
-  el.dataset.copied = "true";
-
-  setTimeout(() => {
-    delete el.dataset.copied;
-  }, 1000);
-
   try {
     await navigator.clipboard.writeText(code);
+
+    el.dataset.copied = "true";
+
+    setTimeout(() => {
+      delete el.dataset.copied;
+    }, 1000);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     // deno-lint-ignore no-console


### PR DESCRIPTION
I noticed that in denoland/fresh#3393 it looks like it's possible that the "Copied"/Check icon will be shown even if copying to clipboard fails.

This PR changes it so that the Check icon only shows if copy succeeds.