### PR TITLE
fix: show help text and refresh help formatting

### DIFF
--- a/packages/init/src/init.ts
+++ b/packages/init/src/init.ts
@@ -2,6 +2,7 @@
 import * as colors from "@std/fmt/colors";
 import * as path from "@std/path";
 import * as semver from "@std/semver";
+import initConfig from "../deno.json" with { type: "json" };
 
 // Keep these as is, as we replace these version in our release script
 const FRESH_VERSION = "2.0.0";
@@ -32,26 +33,36 @@ function error(message: string): never {
   throw new InitError();
 }
 
-export const HELP_TEXT = `@fresh/init
+export const HELP_TEXT = `
+${
+  colors.bgRgb8(
+    colors.rgb8(
+      ` 🍋 @fresh/init${colors.rgb8(`@${initConfig.version}`, 248)} `,
+      0,
+    ),
+    121,
+  )
+}
 
-Initialize a new Fresh project. This will create all the necessary files for a
-new project.
+Initialize a new Fresh project. This will create all the necessary files
+for a new project.
 
 To generate a project in the './foobar' subdirectory:
-  deno run -Ar jsr:@fresh/init ./foobar
+    ${colors.rgb8("deno run -Ar jsr:@fresh/init ./foobar", 245)}
 
 To generate a project in the current directory:
-  deno run -Ar jsr:@fresh/init .
+    ${colors.rgb8("deno run -Ar jsr:@fresh/init .", 245)}
 
-USAGE:
-    deno run -Ar jsr:@fresh/init [DIRECTORY]
+${colors.rgb8("USAGE:", 3)}
+    ${colors.rgb8("deno run -Ar jsr:@fresh/init [DIRECTORY]", 245)}
 
-OPTIONS:
-    --force      Overwrite existing files
-    --tailwind   Use Tailwind for styling
-    --vscode     Setup project for VS Code
-    --docker     Setup Project to use Docker
-    --builder    Setup with builder instead of vite
+${colors.rgb8("OPTIONS:", 3)}
+    ${colors.rgb8("--force", 2)}      Overwrite existing files
+    ${colors.rgb8("--tailwind", 2)}   Use Tailwind for styling
+    ${colors.rgb8("--vscode", 2)}     Setup project for VS Code
+    ${colors.rgb8("--docker", 2)}     Setup Project to use Docker
+    ${colors.rgb8("--builder", 2)}    Setup with builder instead of vite
+    ${colors.rgb8("--help, -h", 2)}   Show this help message
 `;
 
 export const CONFIRM_EMPTY_MESSAGE =
@@ -73,8 +84,17 @@ export async function initProject(
     tailwind?: boolean | null;
     vscode?: boolean | null;
     builder?: boolean | null;
+    help?: boolean | null;
+    h?: boolean | null;
   } = {},
 ): Promise<void> {
+  const freshVersion = await getLatestVersion("@fresh/core", FRESH_VERSION);
+
+  if (flags.help || flags.h) {
+    console.log(HELP_TEXT);
+    return;
+  }
+
   console.log();
   console.log(
     colors.bgRgb8(
@@ -82,6 +102,7 @@ export async function initProject(
       121,
     ),
   );
+  console.log(`    version ${colors.rgb8(freshVersion, 4)}`);
   console.log();
 
   let unresolvedDirectory = Deno.args[0];
@@ -534,8 +555,6 @@ if (Deno.args.includes("build")) {
   if (!useVite) {
     await writeFile("dev.ts", DEV_TS);
   }
-
-  const freshVersion = await getLatestVersion("@fresh/core", FRESH_VERSION);
 
   const denoJson = {
     nodeModulesDir: "auto",

--- a/packages/init/src/init_test.ts
+++ b/packages/init/src/init_test.ts
@@ -3,6 +3,7 @@ import {
   CONFIRM_TAILWIND_MESSAGE,
   CONFIRM_VITE_MESSAGE,
   CONFIRM_VSCODE_MESSAGE,
+  HELP_TEXT,
   initProject,
 } from "./init.ts";
 import * as path from "@std/path";
@@ -24,6 +25,14 @@ function stubConfirm(steps: Record<string, boolean> = {}) {
     globalThis,
     "confirm",
     (message) => message ? steps[message] : false,
+  );
+}
+
+function stubLogs() {
+  return stub(
+    console,
+    "log",
+    () => undefined,
   );
 }
 
@@ -74,6 +83,18 @@ async function readProjectFile(dir: string, pathname: string): Promise<string> {
   const content = await Deno.readTextFile(filePath);
   return content;
 }
+
+Deno.test("init - show help", async () => {
+  using logs = stubLogs();
+
+  await initProject("", [], { help: true });
+  const args = logs.calls.flatMap((c) => c.args);
+  const out = args.join("\n");
+  await initProject("", [], { h: true });
+
+  expect(out).toBe(HELP_TEXT);
+  expect(args).toEqual(logs.calls.flatMap((c) => c.args).slice(args.length));
+});
 
 Deno.test("init - new project", async () => {
   await using tmp = await withTmpDir();


### PR DESCRIPTION
- Show help text when `-h` or `--help` is passed to `@fresh/init`
- Print current version for `@fresh/init` during `--help`
  <img width="367" height="95" alt="image" src="https://github.com/user-attachments/assets/e3318fae-ce8a-4cbb-bb0a-78f338f1b3a2" />
- Refresh `--help` text with colors similar to `deno -h`; + "Fresh branding" style for the `@fresh/init` text
- Print `@fresh/core` version when `@fresh/init` runs
  <img width="471" height="88" alt="image" src="https://github.com/user-attachments/assets/1a0bd619-315d-4abb-889c-ec6eb3a9b45f" />

I think showing versions is helpful for verifying/debugging what Fresh version will be installed during init before all files are generated.

## Comparisons

### `@fresh/init` + empty project name

#### Before

<img width="1104" height="615" alt="image" src="https://github.com/user-attachments/assets/b1534bb5-eecc-4692-9977-df3903868416" />

#### After

<img width="1169" height="695" alt="image" src="https://github.com/user-attachments/assets/6a743d79-bb59-463a-aadd-fbf734149258" />

### `@fresh/init --help`

#### Before

<img width="1007" height="150" alt="image" src="https://github.com/user-attachments/assets/0ad42078-420c-4dc6-9561-4a338cc09741" />

#### After

<img width="1272" height="579" alt="image" src="https://github.com/user-attachments/assets/3dfe6712-8604-4429-a418-5e6538117303" />