### PR TITLE
ci: fix publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,5 +23,8 @@ jobs:
         with:
           cache: true
 
+      - name: Install dependencies
+        run: deno install
+
       - name: Publish
         run: deno publish


### PR DESCRIPTION
Looks like the `publish.yml` workflow also needs a `deno install` step, the current one fails with missing types, see here -> https://github.com/denoland/fresh/actions/runs/18017720086/job/51266850091#step:4:6

I have no clue why the `deploy.yml` workflow failed with `vite: command not found` (see here -> https://github.com/denoland/fresh/actions/runs/18017526863/job/51266206092?pr=3493#step:4:6).
That should work IMHO.