### PR TITLE
 docs: troubleshoot dependency installation

### DIFF
--- a/docs/latest/advanced/troubleshooting.md
+++ b/docs/latest/advanced/troubleshooting.md
@@ -6,6 +6,19 @@ description: |
 This site contains some tips to troubleshoot your app in case something doesn't
 work as expected.
 
+## Install or re-install dependencies
+
+When run for the first time, you might see Deno complaining about missing
+packages. Install them with:
+
+```shell
+deno install --allow-scripts
+```
+
+If you run into dependency trouble later and suspect that Deno might be caching
+an outdated package, you can force a clean reinstall by adding `-r` to the above
+command.
+
 ## Update Fresh
 
 The easiest way to resolve most issues is to ensure that you're on the

--- a/docs/latest/getting-started/index.md
+++ b/docs/latest/getting-started/index.md
@@ -28,7 +28,7 @@ project folder should look like this:
 │   ├── _app.tsx        # Renders the outer <html> content structure
 │   └── index.tsx       # Renders /
 ├── static/             # Contains static assets like css, logos, etc
-│   └── ...       
+│   └── ...
 │
 ├── client.ts       # Client entry file that's loaded on every page.
 ├── main.ts         # The server entry file of your app
@@ -45,6 +45,10 @@ deno task dev
 Go to the URL printed in the terminal to view your app.
 
 ![Screenshot of the newly initialized Fresh app showing a counter](/docs/getting-started-1-init.jpg)
+
+> [info]: If you encounter any problems during setup or development, check the
+> [troubleshooting guide](/docs/latest/advanced/troubleshooting) for common
+> issues and solutions.
 
 ## Creating our first route
 


### PR DESCRIPTION
This adds:
- a short blurb about missing dependencies to the troubleshooting guide
- a hint to this guide in the getting starting page