### PR TITLE
fix(vite): support jsx namespaces

### DIFF
--- a/packages/plugin-vite/demo/routes/tests/jsx_namespace.tsx
+++ b/packages/plugin-vite/demo/routes/tests/jsx_namespace.tsx
@@ -1,0 +1,9 @@
+export default function Page() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      xml:space="preserve"
+    >
+    </svg>
+  );
+}

--- a/packages/plugin-vite/src/plugins/deno.ts
+++ b/packages/plugin-vite/src/plugins/deno.ts
@@ -375,6 +375,7 @@ function babelTransform(
       runtime: "automatic",
       importSource: "preact",
       development: isDev,
+      throwIfNamespace: false,
     }]);
   }
 

--- a/packages/plugin-vite/src/plugins/patches.ts
+++ b/packages/plugin-vite/src/plugins/patches.ts
@@ -33,6 +33,7 @@ export function patches(): Plugin {
             runtime: "automatic",
             importSource: "preact",
             development: isDev,
+            throwIfNamespace: false,
           }]);
         }
 

--- a/packages/plugin-vite/tests/dev_server_test.ts
+++ b/packages/plugin-vite/tests/dev_server_test.ts
@@ -490,3 +490,14 @@ Deno.test({
   sanitizeOps: false,
   sanitizeResources: false,
 });
+
+Deno.test({
+  name: "vite dev - support jsx namespace",
+  fn: async () => {
+    const res = await fetch(`${demoServer.address()}/tests/jsx_namespace`);
+    const text = await res.text();
+    expect(text).toContain(`xml:space="preserve"`);
+  },
+  sanitizeOps: false,
+  sanitizeResources: false,
+});


### PR DESCRIPTION
Babel throws when encountering jsx namespaces by default. It needs a setting to not throw.