### PR TITLE
fix(vite): empty commonjs files with only __esModule

### DIFF
--- a/packages/plugin-vite/src/plugins/patches/commonjs.ts
+++ b/packages/plugin-vite/src/plugins/patches/commonjs.ts
@@ -134,7 +134,7 @@ export function cjsPlugin(
             );
           }
 
-          if (exported.size > 0 || exportedNs.size > 0) {
+          if (exported.size > 0 || exportedNs.size > 0 || hasEsModule) {
             path.unshiftContainer(
               "body",
               t.expressionStatement(

--- a/packages/plugin-vite/src/plugins/patches/commonjs_test.ts
+++ b/packages/plugin-vite/src/plugins/patches/commonjs_test.ts
@@ -134,7 +134,8 @@ ${EXPORT_ES_MODULE}`,
 Deno.test("commonjs - esModule flag only", () => {
   runTest({
     input: `Object.defineProperty(exports, "__esModule", { value: true });`,
-    expected: `Object.defineProperty(exports, "__esModule", {
+    expected: `${INIT}
+Object.defineProperty(exports, "__esModule", {
   value: true
 });
 const _default = exports.default ?? exports;
@@ -148,7 +149,8 @@ Deno.test("commonjs - esModule flag only #2", () => {
   runTest({
     input:
       `Object.defineProperty(module.exports, "__esModule", { value: true });`,
-    expected: `Object.defineProperty(module.exports, "__esModule", {
+    expected: `${INIT}
+Object.defineProperty(module.exports, "__esModule", {
   value: true
 });
 const _default = exports.default ?? exports;
@@ -161,7 +163,8 @@ ${EXPORT_ES_MODULE}`,
 Deno.test("commonjs - esModule flag only minified #3", () => {
   runTest({
     input: `Object.defineProperty(exports, '__esModule', { value: !0 });`,
-    expected: `Object.defineProperty(exports, '__esModule', {
+    expected: `${INIT}
+Object.defineProperty(exports, '__esModule', {
   value: !0
 });
 const _default = exports.default ?? exports;
@@ -692,7 +695,8 @@ Deno.test("commonjs - minified __esModule", () => {
 const m = module.exports;
 const a = Object.defineProperty;
 a(m, "__esModule", { value: !0 });`,
-    expected: `const m = module.exports;
+    expected: `${INIT}
+const m = module.exports;
 const a = Object.defineProperty;
 a(m, "__esModule", {
   value: !0


### PR DESCRIPTION
When modules only contain the `__esModule` flag, we still need to add the `exports` and `module.exports` initializers.