### PR TITLE
fix(vite): ignore tmp, timestamp, test, and dotfiles

### DIFF
--- a/packages/plugin-vite/src/mod.ts
+++ b/packages/plugin-vite/src/mod.ts
@@ -62,6 +62,19 @@ export function fresh(config?: FreshViteConfig): Plugin[] {
         isDev = env.command === "serve";
 
         return {
+          server: {
+            watch: {
+              // Don't watch test files, temp files, or hidden files during development
+              // to prevent dev server crashes
+              ignored: [
+                "**/*_test.ts*",
+                "**/*.test.ts*",
+                "**/*.tmp.*",
+                "**/.timestamp-*",
+                "**/.*",
+              ],
+            },
+          },
           esbuild: {
             jsx: "automatic",
             jsxImportSource: "preact",

--- a/packages/plugin-vite/src/mod.ts
+++ b/packages/plugin-vite/src/mod.ts
@@ -70,7 +70,7 @@ export function fresh(config?: FreshViteConfig): Plugin[] {
                 "**/*_test.ts*",
                 "**/*.test.ts*",
                 "**/*.tmp.*",
-                "**/.timestamp-*",
+                "**/*.timestamp-*",
                 "**/.*",
               ],
             },


### PR DESCRIPTION
Fixes #3585 by ignoring files that were causing Vite to crash, as well as test files, which Vite doesn't need to watch