### PR TITLE
fix(test): ensure test infrastructure respects file skip patterns

### DIFF
--- a/packages/fresh/src/dev/fs_crawl_test.ts
+++ b/packages/fresh/src/dev/fs_crawl_test.ts
@@ -18,3 +18,28 @@ Deno.test("walkDir - ", async () => {
 
   expect(files).toEqual(["foo/bar/baz.txt", "foo/bar.txt"]);
 });
+
+Deno.test("walkDir - respects skip patterns", async () => {
+  const fs = createFakeFs({
+    "routes/index.tsx": "foo",
+    "routes/index_test.tsx": "test",
+    "routes/about.tsx": "foo",
+    "routes/about.test.ts": "test",
+    "routes/api/users.ts": "foo",
+    "routes/api/users_test.ts": "test",
+  });
+
+  const files: string[] = [];
+  const TEST_FILE_PATTERN = /[._]test\.(?:[tj]sx?|[mc][tj]s)$/;
+
+  await walkDir(fs, "routes", async (entry) => {
+    files.push(entry.path);
+  }, [TEST_FILE_PATTERN]);
+
+  // Should only include non-test files
+  expect(files).toEqual([
+    "routes/index.tsx",
+    "routes/about.tsx",
+    "routes/api/users.ts",
+  ]);
+});

--- a/packages/fresh/src/test_utils.ts
+++ b/packages/fresh/src/test_utils.ts
@@ -102,8 +102,14 @@ export function serveMiddleware<T>(
 export function createFakeFs(files: Record<string, unknown>): FsAdapter {
   return {
     cwd: () => ".",
-    async *walk(_root) {
+    async *walk(_root, options) {
+      const skip = options?.skip ?? [];
       for (const file of Object.keys(files)) {
+        // Check if file matches any skip pattern
+        if (skip.some((pattern) => pattern.test(file))) {
+          continue;
+        }
+
         const entry: WalkEntry = {
           isDirectory: false,
           isFile: true,


### PR DESCRIPTION
Updates createFakeFs() to properly implement the skip parameter
from WalkOptions, ensuring test files are filtered out during
route discovery in tests.

While Fresh's production Builder correctly excludes test files
via TEST_FILE_PATTERN by default, the test infrastructure's
createFakeFs() was not implementing the skip parameter, preventing
proper validation of this behavior.

Changes:

- Modified createFakeFs().walk() to accept and process options.skip
- Added test to verify walkDir() respects skip patterns
- Added test to verify test files are excluded from route discovery
- Ensures routes like routes/index_test.tsx are properly filtered
