### PR TITLE
fix(vite): exclude test files from production builds

### DIFF
--- a/packages/fresh/src/constants.ts
+++ b/packages/fresh/src/constants.ts
@@ -12,3 +12,5 @@ export const WEEK = DAY * 7;
 export const ASSET_CACHE_BUST_KEY = "__frsh_c";
 
 export const UPDATE_INTERVAL = DAY;
+
+export const TEST_FILE_PATTERN = /[._]test\.(?:[tj]sx?|[mc][tj]s)$/;

--- a/packages/fresh/src/dev/builder.ts
+++ b/packages/fresh/src/dev/builder.ts
@@ -25,7 +25,7 @@ import { parseDirPath } from "../config.ts";
 import { pathToExportName, UniqueNamer } from "../utils.ts";
 import { checkDenoCompilerOptions } from "./check.ts";
 import { crawlFsItem } from "./fs_crawl.ts";
-import { UPDATE_INTERVAL } from "../constants.ts";
+import { TEST_FILE_PATTERN, UPDATE_INTERVAL } from "../constants.ts";
 
 export interface BuildOptions {
   /**
@@ -103,8 +103,6 @@ export type ResolvedBuildConfig = Required<Omit<BuildOptions, "sourceMap">> & {
   buildId: string;
   sourceMap?: FreshBundleOptions["sourceMap"];
 };
-
-const TEST_FILE_PATTERN = /[._]test\.(?:[tj]sx?|[mc][tj]s)$/;
 
 // deno-lint-ignore no-explicit-any
 export class Builder<State = any> {

--- a/packages/fresh/src/dev/fs_crawl_test.ts
+++ b/packages/fresh/src/dev/fs_crawl_test.ts
@@ -32,7 +32,7 @@ Deno.test("walkDir - respects skip patterns", async () => {
   const files: string[] = [];
   const TEST_FILE_PATTERN = /[._]test\.(?:[tj]sx?|[mc][tj]s)$/;
 
-  await walkDir(fs, "routes", async (entry) => {
+  await walkDir(fs, "routes", (entry) => {
     files.push(entry.path);
   }, [TEST_FILE_PATTERN]);
 

--- a/packages/fresh/src/dev/fs_crawl_test.ts
+++ b/packages/fresh/src/dev/fs_crawl_test.ts
@@ -18,3 +18,28 @@ Deno.test("walkDir - ", async () => {
 
   expect(files).toEqual(["foo/bar/baz.txt", "foo/bar.txt"]);
 });
+
+Deno.test("walkDir - respects skip patterns", async () => {
+  const fs = createFakeFs({
+    "routes/index.tsx": "foo",
+    "routes/index_test.tsx": "test",
+    "routes/about.tsx": "foo",
+    "routes/about.test.ts": "test",
+    "routes/api/users.ts": "foo",
+    "routes/api/users_test.ts": "test",
+  });
+
+  const files: string[] = [];
+  const TEST_FILE_PATTERN = /[._]test\.(?:[tj]sx?|[mc][tj]s)$/;
+
+  await walkDir(fs, "routes", async (entry) => {
+    files.push(entry.path);
+  }, [TEST_FILE_PATTERN]);
+
+  // Should only include non-test files
+  expect(files).toEqual([
+    "routes/index.tsx",
+    "routes/about.tsx",
+    "routes/api/users.ts",
+  ]);
+});

--- a/packages/fresh/src/fs_routes_test.tsx
+++ b/packages/fresh/src/fs_routes_test.tsx
@@ -1564,3 +1564,52 @@ Deno.test("fsRoutes - merge group methods", async () => {
   res = await server.post("/bar");
   expect(await res.text()).toEqual("POST ok");
 });
+
+Deno.test("fsRoutes - ignores test files in routes folder", async () => {
+  const fs = createFakeFs({
+    "routes/index.tsx": {
+      default: () => <>index</>,
+    },
+    "routes/index_test.tsx": {
+      default: () => <>index_test</>,
+    },
+    "routes/foo_test.ts": {
+      handler: () => new Response("foo_test"),
+    },
+    "routes/bar.test.ts": {
+      handler: () => new Response("bar_test"),
+    },
+    "routes/baz.test.tsx": {
+      default: () => <>baz_test</>,
+    },
+    "routes/qux_test.js": {
+      handler: () => new Response("qux_test"),
+    },
+    "routes/valid.tsx": {
+      default: () => <>valid</>,
+    },
+  });
+
+  const TEST_FILE_PATTERN = /[._]test\.(?:[tj]sx?|[mc][tj]s)$/;
+  const routeDir = path.join(fs.cwd(), "routes");
+  const rawFiles = await crawlRouteDir(
+    fs,
+    routeDir,
+    [TEST_FILE_PATTERN],
+    () => {},
+  );
+
+  // Only index.tsx and valid.tsx should be found, test files should be filtered out
+  expect(rawFiles.length).toEqual(2);
+  expect(rawFiles.some((f) => f.filePath.includes("index.tsx"))).toBe(true);
+  expect(rawFiles.some((f) => f.filePath.includes("valid.tsx"))).toBe(true);
+
+  // Ensure none of the test files are included
+  expect(rawFiles.some((f) => f.filePath.includes("index_test.tsx"))).toBe(
+    false,
+  );
+  expect(rawFiles.some((f) => f.filePath.includes("foo_test.ts"))).toBe(false);
+  expect(rawFiles.some((f) => f.filePath.includes("bar.test.ts"))).toBe(false);
+  expect(rawFiles.some((f) => f.filePath.includes("baz.test.tsx"))).toBe(false);
+  expect(rawFiles.some((f) => f.filePath.includes("qux_test.js"))).toBe(false);
+});

--- a/packages/fresh/src/internals_dev.ts
+++ b/packages/fresh/src/internals_dev.ts
@@ -12,4 +12,4 @@ export {
 export { specToName } from "./dev/builder.ts";
 export { pathToSpec, UniqueNamer } from "./utils.ts";
 export { updateCheck } from "./dev/update_check.ts";
-export { UPDATE_INTERVAL } from "./constants.ts";
+export { TEST_FILE_PATTERN, UPDATE_INTERVAL } from "./constants.ts";

--- a/packages/fresh/src/test_utils.ts
+++ b/packages/fresh/src/test_utils.ts
@@ -102,8 +102,14 @@ export function serveMiddleware<T>(
 export function createFakeFs(files: Record<string, unknown>): FsAdapter {
   return {
     cwd: () => ".",
-    async *walk(_root) {
+    async *walk(_root, options) {
+      const skip = options?.skip ?? [];
       for (const file of Object.keys(files)) {
+        // Check if file matches any skip pattern
+        if (skip.some((pattern) => pattern.test(file))) {
+          continue;
+        }
+
         const entry: WalkEntry = {
           isDirectory: false,
           isFile: true,

--- a/packages/plugin-vite/demo/routes/index_test.ts
+++ b/packages/plugin-vite/demo/routes/index_test.ts
@@ -1,0 +1,6 @@
+import { assertEquals } from "@std/assert";
+
+// This test file should NOT be bundled into production builds
+Deno.test("index route test", () => {
+  assertEquals(1 + 1, 2);
+});

--- a/packages/plugin-vite/demo/routes/index_test.ts
+++ b/packages/plugin-vite/demo/routes/index_test.ts
@@ -1,6 +1,0 @@
-import { assertEquals } from "@std/assert";
-
-// This test file should NOT be bundled into production builds
-Deno.test("index route test", () => {
-  assertEquals(1 + 1, 2);
-});

--- a/packages/plugin-vite/src/mod.ts
+++ b/packages/plugin-vite/src/mod.ts
@@ -16,6 +16,7 @@ import { patches } from "./plugins/patches.ts";
 import process from "node:process";
 import {
   specToName,
+  TEST_FILE_PATTERN,
   UniqueNamer,
   UPDATE_INTERVAL,
   updateCheck,
@@ -33,7 +34,7 @@ export function fresh(config?: FreshViteConfig): Plugin[] {
     clientEntry: config?.clientEntry ?? "client.ts",
     islandsDir: config?.islandsDir ?? "islands",
     routeDir: config?.routeDir ?? "routes",
-    ignore: config?.ignore ?? [],
+    ignore: config?.ignore ?? [TEST_FILE_PATTERN],
     islandSpecifiers: new Map(),
     namer: new UniqueNamer(),
     checkImports: config?.checkImports ?? [],

--- a/packages/plugin-vite/tests/build_test.ts
+++ b/packages/plugin-vite/tests/build_test.ts
@@ -570,8 +570,8 @@ Deno.test({
 Deno.test({
   name: "vite build - excludes test files from routes",
   fn: async () => {
-    // Rebuild to ensure our changes are picked up
-    await using res = await buildVite(DEMO_DIR);
+    const fixture = path.join(FIXTURE_DIR, "test_files_exclusion");
+    await using res = await buildVite(fixture);
 
     // Verify that test files in routes/ are not bundled
     const serverAssetsDir = path.join(res.tmp, "_fresh", "server", "assets");
@@ -584,19 +584,16 @@ Deno.test({
       }
     }
 
-    console.log("Found route files:", files);
-
-    // index_test.ts should NOT be bundled
+    // Should have index route but NOT test files
+    expect(files.some((f) => f.includes("_fresh-route___index"))).toBe(true);
     expect(files.some((f) => f.includes("index_test"))).toBe(false);
+    expect(files.some((f) => f.includes("foo.test"))).toBe(false);
 
     // Verify no test pattern files at all
     // Note: files with "_test" or ".test" in their name (not just a "tests" folder)
     const testPatterns = ["_test.", "_test-", ".test."];
     for (const file of files) {
       for (const pattern of testPatterns) {
-        if (file.includes(pattern)) {
-          console.error(`ERROR: Found test file in build: ${file}`);
-        }
         expect(file.includes(pattern)).toBe(false);
       }
     }

--- a/packages/plugin-vite/tests/fixtures/test_files_exclusion/deno.json
+++ b/packages/plugin-vite/tests/fixtures/test_files_exclusion/deno.json
@@ -1,0 +1,8 @@
+{
+  "imports": {
+    "fresh": "jsr:@fresh/core@^2.0.0",
+    "@fresh/plugin-vite": "jsr:@fresh/plugin-vite@^1.0.0",
+    "preact": "npm:preact@^10.27.2",
+    "preact/": "npm:/preact@^10.27.2/"
+  }
+}

--- a/packages/plugin-vite/tests/fixtures/test_files_exclusion/main.ts
+++ b/packages/plugin-vite/tests/fixtures/test_files_exclusion/main.ts
@@ -1,0 +1,3 @@
+import { App } from "fresh";
+
+export const app = new App().fsRoutes();

--- a/packages/plugin-vite/tests/fixtures/test_files_exclusion/routes/foo.test.ts
+++ b/packages/plugin-vite/tests/fixtures/test_files_exclusion/routes/foo.test.ts
@@ -1,0 +1,4 @@
+// This test file should NOT be bundled into production
+export const handler = () => {
+  return new Response("This should never be in production");
+};

--- a/packages/plugin-vite/tests/fixtures/test_files_exclusion/routes/index.tsx
+++ b/packages/plugin-vite/tests/fixtures/test_files_exclusion/routes/index.tsx
@@ -1,0 +1,3 @@
+export default function Home() {
+  return <div>ok</div>;
+}

--- a/packages/plugin-vite/tests/fixtures/test_files_exclusion/routes/index_test.tsx
+++ b/packages/plugin-vite/tests/fixtures/test_files_exclusion/routes/index_test.tsx
@@ -1,0 +1,4 @@
+// This test file should NOT be bundled into production
+export default function TestRoute() {
+  return <div>This should never be in production</div>;
+}

--- a/packages/plugin-vite/tests/fixtures/test_files_exclusion/vite.config.ts
+++ b/packages/plugin-vite/tests/fixtures/test_files_exclusion/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from "vite";
+import { fresh } from "@fresh/plugin-vite";
+
+export default defineConfig({
+  plugins: [fresh()],
+});


### PR DESCRIPTION
The Vite plugin was not filtering out test files from route discovery,
causing test files in routes/ (e.g., routes/api/counter_test.ts) to be
bundled into production builds, inflating bundle sizes by ~20KB per test
file and including unnecessary test dependencies.

Root cause: Vite plugin defaulted ignore patterns to [] while Builder
correctly defaults to [TEST_FILE_PATTERN].

This fix:

- Defines TEST_FILE_PATTERN in shared constants.ts for reusability
- Exports TEST_FILE_PATTERN from internals_dev.ts for Vite plugin access
- Updates Vite plugin default from [] to [TEST_FILE_PATTERN]
- Updates Builder to import TEST_FILE_PATTERN from constants.ts
- Ensures test files matching /[._]test\.(?:[tj]sx?|[mc][tj]s)$/ are
excluded
- Adds integration test to prevent regression
- Allows Deno best practice of colocating test files without bundling them

Test coverage (prevents regression):

- Unit test: walkDir respects skip patterns
- Unit test: crawlRouteDir excludes test files
- Integration test: Vite builds exclude test files from output

Fixes #3558
