### PR TITLE
Improve outDir configuration for builds

### DIFF
--- a/packages/plugin-vite/src/mod.ts
+++ b/packages/plugin-vite/src/mod.ts
@@ -108,7 +108,10 @@ export function fresh(config?: FreshViteConfig): Plugin[] {
                 copyPublicDir: false,
                 manifest: true,
 
-                outDir: config.environments?.client?.build?.outDir ?? (config.build?.outdir ? config.build.outdir + "/client" : null) ??
+                outDir: config.environments?.client?.build?.outDir ??
+                  (config.build?.outDir
+                    ? config.build.outDir + "/client"
+                    : null) ??
                   "_fresh/client",
                 rollupOptions: {
                   preserveEntrySignatures: "strict",
@@ -124,7 +127,10 @@ export function fresh(config?: FreshViteConfig): Plugin[] {
                 emitAssets: true,
                 copyPublicDir: false,
 
-                outDir: config.environments?.ssr?.build?.outDir ?? (config.build?.outdir ? config.build.outdir + "/server" : null) ??
+                outDir: config.environments?.ssr?.build?.outDir ??
+                  (config.build?.outDir
+                    ? config.build.outDir + "/server"
+                    : null) ??
                   "_fresh/server",
                 rollupOptions: {
                   onwarn(warning, handler) {

--- a/packages/plugin-vite/src/mod.ts
+++ b/packages/plugin-vite/src/mod.ts
@@ -108,7 +108,7 @@ export function fresh(config?: FreshViteConfig): Plugin[] {
                 copyPublicDir: false,
                 manifest: true,
 
-                outDir: config.environments?.client?.build?.outDir ??
+                outDir: config.environments?.client?.build?.outDir ?? (config.build?.outdir ? config.build.outdir + "/client" : null) ??
                   "_fresh/client",
                 rollupOptions: {
                   preserveEntrySignatures: "strict",
@@ -124,7 +124,7 @@ export function fresh(config?: FreshViteConfig): Plugin[] {
                 emitAssets: true,
                 copyPublicDir: false,
 
-                outDir: config.environments?.ssr?.build?.outDir ??
+                outDir: config.environments?.ssr?.build?.outDir ?? (config.build?.outdir ? config.build.outdir + "/server" : null) ??
                   "_fresh/server",
                 rollupOptions: {
                   onwarn(warning, handler) {


### PR DESCRIPTION
The Vite outDir setting is confusingly ignored, which is not documented in the plugin documentation. This corrects that, while still preferring the more specific environment settings.