### PR TITLE
docs: fix two typos

### DIFF
--- a/docs/latest/examples/rendering-raw-html.md
+++ b/docs/latest/examples/rendering-raw-html.md
@@ -27,6 +27,6 @@ rendering markdown.
 
 > [warn]: Setting arbitrary HTML can be dangerous, hence the
 > `dangerouslySetInnerHTML` naming. Make sure you trust the source. Rendering
-> user-supplied HTML to the DOM makes your site vulnerable to cross- site
-> scripting. The markup must first be sanitizied, or better yet, something you
+> user-supplied HTML to the DOM makes your site vulnerable to cross-site
+> scripting. The markup must first be sanitized, or better yet, something you
 > trust.


### PR DESCRIPTION
fixes two tiny erros in the docs