### PR TITLE
docs: add a notice about main.tsx, how to switch from main.ts

### DIFF
--- a/docs/latest/advanced/app-wrapper.md
+++ b/docs/latest/advanced/app-wrapper.md
@@ -8,6 +8,10 @@ structure of the HTML document, typically up until the `<body>`-tag. It is only
 rendered on the server and never on the client. The passed `Component` value
 represents the children of this component.
 
+> [warn]: If you have just started a fresh new project, the entry file will
+> will be `main.ts`, not `main.tsx`. If that's the case, rename it, then
+> edit the [vite config](/docs/advanced/vite), set `serverEntry: "./main.tsx",`.
+
 ```tsx main.tsx
 function AppWrapper({ Component }) {
   return (

--- a/docs/latest/advanced/app-wrapper.md
+++ b/docs/latest/advanced/app-wrapper.md
@@ -8,9 +8,9 @@ structure of the HTML document, typically up until the `<body>`-tag. It is only
 rendered on the server and never on the client. The passed `Component` value
 represents the children of this component.
 
-> [warn]: If you have just started a fresh new project, the entry file will
-> will be `main.ts`, not `main.tsx`. If that's the case, rename it, then
-> edit the [vite config](/docs/advanced/vite), set `serverEntry: "./main.tsx",`.
+> [warn]: If you have just started a fresh new project, the entry file will will
+> be `main.ts`, not `main.tsx`. If that's the case, rename it, then edit the
+> [vite config](/docs/advanced/vite), set `serverEntry: "./main.tsx",`.
 
 ```tsx main.tsx
 function AppWrapper({ Component }) {


### PR DESCRIPTION

<img width="901" height="644" alt="Screenshot 2025-10-25 at 22 17 27" src="https://github.com/user-attachments/assets/f8630253-a908-46ec-8860-67356f14eba4" />


The code example's title instructs to use `main.tsx` but the project starter uses `main.ts`. Let's add a warning to tell users to configure vite after renaming this entry file.