### PR TITLE
fix(partial): buttons outside forms should not trigger navigation

### DIFF
--- a/packages/fresh/src/runtime/client/partials.ts
+++ b/packages/fresh/src/runtime/client/partials.ts
@@ -132,7 +132,7 @@ document.addEventListener("click", async (e) => {
           partial ? partial : nextUrl.href,
           location.href,
         );
-        await fetchPartials(nextUrl, partialUrl);
+        await fetchPartials(nextUrl, partialUrl, true);
         updateLinks(nextUrl);
         scrollTo({ left: 0, top: 0, behavior: "instant" });
       } finally {
@@ -155,7 +155,7 @@ document.addEventListener("click", async (e) => {
         partial,
         location.href,
       );
-      await fetchPartials(partialUrl, partialUrl);
+      await fetchPartials(partialUrl, partialUrl, false);
     }
   }
 });
@@ -192,7 +192,7 @@ addEventListener("popstate", async (e) => {
 
   const url = new URL(location.href, location.origin);
   try {
-    await fetchPartials(url, url);
+    await fetchPartials(url, url, true);
     updateLinks(url);
     scrollTo({
       left: state.scrollX ?? 0,
@@ -254,7 +254,7 @@ document.addEventListener("submit", async (e) => {
         init = { body: new FormData(el, e.submitter), method: lowerMethod };
       }
 
-      await fetchPartials(actionUrl, partialUrl, init);
+      await fetchPartials(actionUrl, partialUrl, true, init);
     }
   }
 });
@@ -282,6 +282,7 @@ function updateLinks(url: URL) {
 async function fetchPartials(
   actualUrl: URL,
   partialUrl: URL,
+  shouldNavigate: boolean,
   init: RequestInit = {},
 ) {
   init.redirect = "follow";
@@ -296,7 +297,10 @@ async function fetchPartials(
     }
   }
 
-  maybeUpdateHistory(actualUrl);
+  if (shouldNavigate) {
+    maybeUpdateHistory(actualUrl);
+  }
+
   await applyPartials(res);
 }
 


### PR DESCRIPTION
`<button>` elements that are not inside a form and have a `f-partial` attribute should not trigger a history change.

Fixes https://github.com/denoland/fresh/pull/3584