### PR TITLE
docs(build-id): add code block example

### DIFF
--- a/packages/build-id/mod.ts
+++ b/packages/build-id/mod.ts
@@ -1,3 +1,17 @@
+/**
+ * Don't use this package directly. It's considered internal for Fresh.
+ *
+ * @example
+ * ```ts
+ * // `BUILD_ID` is based on the `DENO_DEPLOYMENT_ID` environment variable.
+ * ```
+ *
+ * @see https://fresh.deno.dev/docs/deployment/docker
+ *
+ * @module
+ * @private
+ */
+
 import { encodeHex } from "@std/encoding/hex";
 
 export const DENO_DEPLOYMENT_ID: string | undefined = Deno.env.get(


### PR DESCRIPTION
Adds a module doc and code block to help satisfy JSR's scoring. Suggestions for alternatives or improvements very welcome.

Part of #3597