### PR TITLE
docs(core): correct example code block formatting

### DIFF
--- a/packages/fresh/src/middlewares/csp.ts
+++ b/packages/fresh/src/middlewares/csp.ts
@@ -12,16 +12,21 @@ export interface CSPOptions {
   csp?: string[];
 }
 
-/** Middleware to set Content-Security-Policy headers
+/**
+ * Middleware to set Content-Security-Policy headers
+ *
  * @param options - CSP options
- * @example
+ *
+ * @example Basic usage
+ * ```ts
  * app.use(csp({
  *   reportOnly: true,
  *   reportTo: '/api/csp-reports',
  *   csp: [
- *       "script-src 'self' 'unsafe-inline' 'https://example.com'",
+ *     "script-src 'self' 'unsafe-inline' 'https://example.com'",
  *   ],
  * }));
+ * ```
  */
 export function csp<State>(options: CSPOptions = {}): Middleware<State> {
   const {


### PR DESCRIPTION
The example for the CSP middleware looks a bit broken currently on JSR, due to the `@example` markdown is not wrapped in a code block. 

<img width="1136" height="247" alt="image" src="https://github.com/user-attachments/assets/57888033-aa9e-4701-87dc-4f4810365177" />

## Changes

- Improves formatting a bit, to be less compact
- Wraps the example in a code block ` ```ts `
- Adds a title to the `@example` - "Basic usage" - To avoid the example being labeled as "Example1" on JSR
