### PR TITLE
docs(core): improve CORS example documentation on JSR

### DIFF
--- a/packages/fresh/src/dev/builder.ts
+++ b/packages/fresh/src/dev/builder.ts
@@ -213,7 +213,7 @@ export class Builder<State = any> {
    * This can also be used for testing to apply a snapshot to a particular
    * {@linkcode App} instance.
    *
-   * @example
+   * @example Testing
    * ```ts
    * const builder = new Builder();
    * const applySnapshot = await builder.build({ snapshot: "memory" });

--- a/packages/fresh/src/middlewares/cors.ts
+++ b/packages/fresh/src/middlewares/cors.ts
@@ -37,7 +37,7 @@ export type CORSOptions<State> = {
  * @param [options] - The options for the CORS middleware.
  * @returns The Fresh middleware handler function.
  *
- * @example
+ * @example Basic usage
  * ```ts
  * // main.ts or routes/_middleware.ts
  * import { cors } from 'fresh';
@@ -46,19 +46,21 @@ export type CORSOptions<State> = {
  *   cors({ origin: '*' }), // Allow all origins
  *   // other middlewares or main route handler
  * ];
+ * ```
  *
- * // Example with options:
- * // export const handler = [
- * //   cors({
- * //     origin: 'http://example.com',
- * //     allowHeaders: ['X-Custom-Header', 'Upgrade-Insecure-Requests'],
- * //     allowMethods: ['POST', 'GET', 'OPTIONS'],
- * //     exposeHeaders: ['Content-Length', 'X-Kuma-Revision'],
- * //     maxAge: 600,
- * //     credentials: true,
- * //   }),
- * //   // ...
- * // ];
+ * @example Advanced usage
+ * ```ts
+ * export const handler = [
+ *   cors({
+ *     origin: 'http://example.com',
+ *     allowHeaders: ['X-Custom-Header', 'Upgrade-Insecure-Requests'],
+ *     allowMethods: ['POST', 'GET', 'OPTIONS'],
+ *     exposeHeaders: ['Content-Length', 'X-Kuma-Revision'],
+ *     maxAge: 600,
+ *     credentials: true,
+ *   }),
+ *   // ...
+ * ];
  * ```
  */
 export function cors<State>(options?: CORSOptions<State>): Middleware<State> {


### PR DESCRIPTION
Improves clarity of CORS JSDoc example for JSR:

<img width="1088" height="706" alt="image" src="https://github.com/user-attachments/assets/8ea3b6f9-a5ee-41cc-9512-a3a0fb87a4c0" />

## Changes

- Split the example into two: Basic & Advances
- Uncomment "Advanced" example