### PR TITLE
docs(examples): add module and public exports JSDoc for all entrypoints

### DIFF
--- a/packages/examples/src/app1.tsx
+++ b/packages/examples/src/app1.tsx
@@ -1,6 +1,13 @@
+/**
+ * Module containing a simple example Fresh App
+ *
+ * @module
+ */
+
 import { App } from "fresh";
 import { Doc } from "./shared.tsx";
 
+/** App that renders a sample HTML document */
 export const app1: App<unknown> = new App()
   .get("/", (ctx) =>
     ctx.render(

--- a/packages/examples/src/app2.tsx
+++ b/packages/examples/src/app2.tsx
@@ -1,6 +1,13 @@
+/**
+ * Module containing a simple example Fresh App
+ *
+ * @module
+ */
+
 import { App } from "fresh";
 import { Doc } from "./shared.tsx";
 
+/** App that renders a sample HTML document */
 export const app2: App<unknown> = new App()
   .get("/", (ctx) =>
     ctx.render(

--- a/packages/examples/src/island.tsx
+++ b/packages/examples/src/island.tsx
@@ -1,6 +1,24 @@
+/**
+ * Example of external Fresh Island component.
+ *
+ * @example
+ * ```tsx
+ * import { App } from "fresh";
+ * import { DemoIsland } from "jsr:@fresh/examples/island";
+ *
+ * const app = new App();
+ *
+ * // Use the island somewhere in your components
+ * app.get("/", (ctx) => ctx.render(<DemoIsland />));
+ * ```
+ *
+ * @module
+ */
+
 import { useSignal } from "@preact/signals";
 import type { JSX } from "preact";
 
+/** A simple counter demo island component using Preact signals */
 export function DemoIsland(): JSX.Element {
   const count = useSignal(0);
 


### PR DESCRIPTION
Addresses scoring of `@fresh/examples` of JSR for several metrics:

- ✅ Adds module doc for all entrypoints
- ✅ Adds descriptions to all public exports for `@fresh/examples` (0% -> 100%)

I could not find if `@fresh/examples` are part of any E2E tests to test using JSR package as mounted app or Island, or if this is just a small demo for users. So I just added small generic drescriptions.

Part of #3597