### PR TITLE
docs(vite-plugin): add JSDoc and export public API

### DIFF
--- a/packages/plugin-vite/src/client.ts
+++ b/packages/plugin-vite/src/client.ts
@@ -1,3 +1,13 @@
+/**
+ * Used internally by the `@fresh/plugin-vite` to add HMR support
+ * for Fresh running in the browser.
+ *
+ * **Do not** import this module directly.
+ *
+ * @module
+ * @private
+ */
+
 import type { UpdatePayload } from "vite";
 import { hashCode } from "./shared.ts";
 

--- a/packages/plugin-vite/src/mod.ts
+++ b/packages/plugin-vite/src/mod.ts
@@ -27,7 +27,32 @@ import { load as stdLoadEnv } from "@std/dotenv";
 import path from "node:path";
 
 export type { FreshViteConfig };
+export type {
+  ImportCheck,
+  ImportCheckDiagnostic,
+} from "./plugins/verify_imports.ts";
 
+/**
+ * Fresh framework support for Vite.
+ *
+ * This plugin uses the Environments feature of Vite to build
+ * both the server and client code for Fresh applications.
+ *
+ * @param config Fresh config options
+ * @returns Vite plugin with Fresh support
+ *
+ * @example Basic usage
+ * ```ts vite.config.ts
+ * import { defineConfig } from "vite";
+ * import { fresh } from "@fresh/plugin-vite";
+ *
+ * export default defineConfig({
+ *   plugins: [
+ *     fresh({ serverEntry: "server.ts" })
+ *   ],
+ * });
+ * ```
+ */
 export function fresh(config?: FreshViteConfig): Plugin[] {
   const fConfig: ResolvedFreshViteConfig = {
     serverEntry: config?.serverEntry ?? "main.ts",

--- a/packages/plugin-vite/src/plugins/verify_imports.ts
+++ b/packages/plugin-vite/src/plugins/verify_imports.ts
@@ -4,6 +4,7 @@ import type { PluginContext } from "rollup";
 import path from "node:path";
 import { pathWithRoot } from "../utils.ts";
 
+/** A diagnostic message for an invalid import */
 export interface ImportCheckDiagnostic {
   type: "warn" | "error";
   message: string;
@@ -11,6 +12,7 @@ export interface ImportCheckDiagnostic {
   hint?: string;
 }
 
+/** A check whether or not an import is valid or not for an environment */
 export type ImportCheck = (
   id: string,
   env: "ssr" | "client",

--- a/packages/plugin-vite/src/utils.ts
+++ b/packages/plugin-vite/src/utils.ts
@@ -35,14 +35,15 @@ export interface ClientSnapshot {
   entry: string;
 }
 
+/** Configuration options for Fresh when using the Vite plugin */
 export interface FreshViteConfig {
-  /** Path to main server entry file. Default: main.ts */
+  /** Path to main server entry file. Default: `main.ts` */
   serverEntry?: string;
-  /** Path to main client entry file. Default: client.ts */
+  /** Path to main client entry file. Default: `client.ts` */
   clientEntry?: string;
-  /** Path to islands directory. Default: ./islands */
+  /** Path to islands directory. Default: `./islands` */
   islandsDir?: string;
-  /** Path to routes directory. Default: ./routes */
+  /** Path to routes directory. Default: `./routes` */
   routeDir?: string;
   /**
    * Ignore file paths matching any of the provided regexes when
@@ -54,6 +55,13 @@ export interface FreshViteConfig {
    * islands from remote packages.
    */
   islandSpecifiers?: string[];
+  /**
+   * A list of checks that will be performed for imports.
+   *
+   * Can be used to warn or error when certain imports exist in
+   * server or client code. Useful to enforce that some dependencies
+   * are not imported in Islands running in the browser.
+   */
   checkImports?: ImportCheck[];
 }
 


### PR DESCRIPTION
Improves documentation of `@fresh/plugin-vite` related to public API, and exports missing symbols/types that are part of public API (`FreshViteConfig`).

- Adds `@module` JSDoc for the `@fresh/plugin-vite/client` entrypoint
  - Internal only, used for browser HMR
- Exports types `ImportCheck` & `ImportCheckDiagnostic`, as they are part of the public API via `FreshViteConfig`
  - Should make [`ImportCheck` link to correct type](https://jsr.io/@fresh/plugin-vite/doc/~/FreshViteConfig#property_checkimports):
    <img width="1053" height="285" alt="image" src="https://github.com/user-attachments/assets/766c29f7-7f39-429e-bd81-234fed6b0820" />
- Adds JSDoc descriptions for all public exports; `fresh`, `FreshViteConfig`, `ImportCheck` & `ImportCheckDiagnostic`
- Adds description for `FreshViteConfig.checkImports`

Part of #3597 & #3596