### PR TITLE
feat(docs): improve copy button appearance on light mode

### DIFF
--- a/www/utils/markdown.ts
+++ b/www/utils/markdown.ts
@@ -191,7 +191,7 @@ class DefaultRenderer extends Marked.Renderer {
             type="button"
             data-code="${escapeHtml(text)}"
             aria-label="Copy to Clipboard"
-            class="rounded-sm flex items-center justify-center border border-foreground-secondary/30 hover:bg-foreground-secondary/70 data-copied:text-green-300 relative group cursor-pointer w-7 h-7 text-white"
+            class="rounded-sm flex items-center justify-center border border-foreground-secondary/30 hover:bg-foreground-secondary/20 dark:hover:bg-foreground-secondary/70 data-copied:text-green-700 dark:data-copied:text-green-300 relative group cursor-pointer w-7 h-7 dark:text-white"
           >
             <span class="group-copied">
               <svg


### PR DESCRIPTION
| Before| After |
| :---: | :---: |
| ![before](https://github.com/user-attachments/assets/6d485c89-79ec-485d-9897-de9db0a9b044) | ![after](https://github.com/user-attachments/assets/5c134ea1-6dec-4da5-8a84-e7e7b7e062a7) |

The appearance on dark mode doesn't change.
