### PR TITLE
feat(init): use recommended vscode settings for tailwind

### DIFF
--- a/packages/init/src/init.ts
+++ b/packages/init/src/init.ts
@@ -684,7 +684,11 @@ This will watch the project directory and restart as necessary.`;
       "[javascript]": {
         "editor.defaultFormatter": "denoland.vscode-deno",
       },
-      "css.customData": useTailwind ? [".vscode/tailwind.json"] : undefined,
+      "files.associations": useTailwind
+        ? {
+          "*.css": "tailwindcss",
+        }
+        : undefined,
     };
 
     await writeFile(".vscode/settings.json", vscodeSettings);
@@ -692,76 +696,6 @@ This will watch the project directory and restart as necessary.`;
     const recommendations = ["denoland.vscode-deno"];
     if (useTailwind) recommendations.push("bradlc.vscode-tailwindcss");
     await writeFile(".vscode/extensions.json", { recommendations });
-
-    if (useTailwind) {
-      const tailwindCustomData = {
-        "version": 1.1,
-        "atDirectives": [
-          {
-            "name": "@tailwind",
-            "description":
-              "Use the `@tailwind` directive to insert Tailwind's `base`, `components`, `utilities` and `screens` styles into your CSS.",
-            "references": [
-              {
-                "name": "Tailwind Documentation",
-                "url":
-                  "https://tailwindcss.com/docs/functions-and-directives#tailwind",
-              },
-            ],
-          },
-          {
-            "name": "@apply",
-            "description":
-              "Use the `@apply` directive to inline any existing utility classes into your own custom CSS. This is useful when you find a common utility pattern in your HTML that you’d like to extract to a new component.",
-            "references": [
-              {
-                "name": "Tailwind Documentation",
-                "url":
-                  "https://tailwindcss.com/docs/functions-and-directives#apply",
-              },
-            ],
-          },
-          {
-            "name": "@responsive",
-            "description":
-              "You can generate responsive variants of your own classes by wrapping their definitions in the `@responsive` directive:\n```css\n@responsive {\n  .alert {\n    background-color: #E53E3E;\n  }\n}\n```\n",
-            "references": [
-              {
-                "name": "Tailwind Documentation",
-                "url":
-                  "https://tailwindcss.com/docs/functions-and-directives#responsive",
-              },
-            ],
-          },
-          {
-            "name": "@screen",
-            "description":
-              "The `@screen` directive allows you to create media queries that reference your breakpoints by **name** instead of duplicating their values in your own CSS:\n```css\n@screen sm {\n  /* ... */\n}\n```\n…gets transformed into this:\n```css\n@media (min-width: 640px) {\n  /* ... */\n}\n```\n",
-            "references": [
-              {
-                "name": "Tailwind Documentation",
-                "url":
-                  "https://tailwindcss.com/docs/functions-and-directives#screen",
-              },
-            ],
-          },
-          {
-            "name": "@variants",
-            "description":
-              "Generate `hover`, `focus`, `active` and other **variants** of your own utilities by wrapping their definitions in the `@variants` directive:\n```css\n@variants hover, focus {\n   .btn-brand {\n    background-color: #3182CE;\n  }\n}\n```\n",
-            "references": [
-              {
-                "name": "Tailwind Documentation",
-                "url":
-                  "https://tailwindcss.com/docs/functions-and-directives#variants",
-              },
-            ],
-          },
-        ],
-      };
-
-      await writeFile(".vscode/tailwind.json", tailwindCustomData);
-    }
   }
 
   if (!flags.skipInstall) {


### PR DESCRIPTION
The recommended way to configure custom directives from Tailwind is to use `files.associations`.

Check recommended settings from Tailwind CSS IntelliSense Extension: https://github.com/tailwindlabs/tailwindcss-intellisense#recommended-vs-code-settings

This allows us to stop maintaining future changes to custom directives from TailwindCSS, instead letting the TailwindCSS extension decide how to handle them.