### PR TITLE
fix(vite): source mapping locations

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,4 +1,5 @@
 {
+  "vendor": true,
   "nodeModulesDir": "manual",
   "workspace": [
     "./packages/*",
@@ -8,7 +9,7 @@
     "demo": "deno task --cwd=packages/plugin-vite demo",
     "demo:build": "deno task --cwd=packages/plugin-vite demo:build",
     "demo:start": "deno task --cwd=packages/plugin-vite demo:start",
-    "test": "deno test -A --parallel",
+    "test": "deno test -A",
     "www": "deno task --cwd=www dev",
     "build-www": "deno task --cwd=www build",
     "screenshot": "deno run -A www/utils/screenshot.ts",

--- a/packages/fresh/src/internals.ts
+++ b/packages/fresh/src/internals.ts
@@ -1,6 +1,6 @@
 import * as path from "@std/path";
 
-export { setBuildCache } from "./app.ts";
+export { setBuildCache, setErrorInterceptor } from "./app.ts";
 export { IslandPreparer, ProdBuildCache } from "./build_cache.ts";
 export { path };
 export { ASSET_CACHE_BUST_KEY } from "./constants.ts";

--- a/packages/plugin-vite/demo/routes/_error.tsx
+++ b/packages/plugin-vite/demo/routes/_error.tsx
@@ -1,0 +1,9 @@
+import { define } from "../utils.ts";
+
+export default define.page((props) => {
+  if (props.error instanceof Error) {
+    return <pre id="err">{String(props.error?.stack)}</pre>;
+  }
+
+  return <pre id="err">{String(props.error)}</pre>;
+});

--- a/packages/plugin-vite/demo/routes/tests/throw.tsx
+++ b/packages/plugin-vite/demo/routes/tests/throw.tsx
@@ -1,0 +1,7 @@
+import { define } from "../../utils.ts";
+
+export const handler = define.handlers({
+  GET() {
+    throw new Error("FAIL");
+  },
+});

--- a/packages/plugin-vite/demo/utils.ts
+++ b/packages/plugin-vite/demo/utils.ts
@@ -1,0 +1,4 @@
+import { createDefine } from "@fresh/core";
+
+// deno-lint-ignore no-explicit-any
+export const define = createDefine<any>();

--- a/packages/plugin-vite/src/mod.ts
+++ b/packages/plugin-vite/src/mod.ts
@@ -180,6 +180,16 @@ export function fresh(config?: FreshViteConfig): Plugin[] {
                       return;
                     }
 
+                    // Ignore this warnings
+                    if (warning.code === "THIS_IS_UNDEFINED") {
+                      return;
+                    }
+
+                    // Ignore falsy source map errors
+                    if (warning.code === "SOURCEMAP_ERROR") {
+                      return;
+                    }
+
                     return handler(warning);
                   },
                   input: {

--- a/packages/plugin-vite/src/plugins/deno.ts
+++ b/packages/plugin-vite/src/plugins/deno.ts
@@ -384,10 +384,10 @@ function babelTransform(
   const result = babel.transformSync(code, {
     filename: id,
     babelrc: false,
-    sourceMaps: "inline",
+    sourceMaps: "both",
     presets: presets,
     plugins: [httpAbsolute(url)],
-    compact: true,
+    compact: false,
   });
 
   if (result !== null && result.code) {

--- a/packages/plugin-vite/src/plugins/dev_server.ts
+++ b/packages/plugin-vite/src/plugins/dev_server.ts
@@ -72,6 +72,12 @@ export function devServer(): Plugin[] {
           try {
             const mod = await server.ssrLoadModule("fresh:server_entry");
             const req = createRequest(nodeReq, nodeRes);
+            mod.setErrorInterceptor((err: unknown) => {
+              if (err instanceof Error) {
+                server.ssrFixStacktrace(err);
+              }
+            });
+
             const res = (await mod.default.fetch(req)) as Response;
 
             // Collect css eagerly to avoid FOUC. This is a workaround for
@@ -101,6 +107,9 @@ export function devServer(): Plugin[] {
 
             await sendResponse(nodeRes, res);
           } catch (err) {
+            if (err instanceof Error) {
+              server.ssrFixStacktrace(err);
+            }
             return next(err);
           }
         });

--- a/packages/plugin-vite/src/plugins/patches.ts
+++ b/packages/plugin-vite/src/plugins/patches.ts
@@ -50,9 +50,10 @@ export function patches(): Plugin {
         const res = babel.transformSync(code, {
           filename: id,
           babelrc: false,
-          compact: true,
+          compact: false,
           plugins,
           presets,
+          sourceMaps: "both",
         });
 
         if (res?.code) {

--- a/packages/plugin-vite/src/plugins/server_entry.ts
+++ b/packages/plugin-vite/src/plugins/server_entry.ts
@@ -89,7 +89,12 @@ export function registerStaticFile(prepared) {
 
         if (isDev) {
           code = `import "preact/debug";
+import { setErrorInterceptor as internalErrorIntercept } from "fresh/internal";
 ${code}
+
+export function setErrorInterceptor(fn) {
+  internalErrorIntercept(app, fn);
+}
 if (import.meta.hot) import.meta.hot.accept();`;
         }
 

--- a/packages/plugin-vite/tests/dev_server_test.ts
+++ b/packages/plugin-vite/tests/dev_server_test.ts
@@ -523,3 +523,14 @@ Deno.test({
   sanitizeOps: false,
   sanitizeResources: false,
 });
+
+Deno.test({
+  name: "vite dev - source mapped stack traces",
+  fn: async () => {
+    const res = await fetch(`${demoServer.address()}/tests/throw`);
+    const text = await res.text();
+    expect(text).toContain("throw.tsx:5:11");
+  },
+  sanitizeOps: false,
+  sanitizeResources: false,
+});


### PR DESCRIPTION
Mappings were wrong for a few reasons:
- Missing source map generation in one babel transform
- setting `compact: false` causes vite to generate incorrect mappings in `vite:import-analysis`
- stack traces need to be mapped by vite

Fixes https://github.com/denoland/fresh/issues/3609