### PR TITLE
refactor: complete move to Vite Environment API

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -69,12 +69,12 @@
     "jsr:@zip-js/zip-js@^2.7.52": "2.8.8",
     "npm:@babel/core@^7.28.0": "7.28.5",
     "npm:@babel/preset-react@^7.27.1": "7.28.5_@babel+core@7.28.5",
-    "npm:@mjackson/node-fetch-server@0.7": "0.7.0",
     "npm:@opentelemetry/api@^1.9.0": "1.9.0",
     "npm:@preact/signals@2": "2.3.2_preact@10.27.2",
     "npm:@preact/signals@^2.2.1": "2.3.2_preact@10.27.2",
     "npm:@prefresh/vite@^2.4.8": "2.4.11_preact@10.27.2_vite@7.1.12__@types+node@24.9.2__picomatch@4.0.3_@types+node@24.9.2",
     "npm:@radix-ui/themes@^3.2.1": "3.2.1_react@19.1.1_react-dom@19.1.1__react@19.1.1",
+    "npm:@remix-run/node-fetch-server@0.12": "0.12.0",
     "npm:@supabase/postgrest-js@^1.21.4": "1.21.4",
     "npm:@tailwindcss/postcss@^4.1.10": "4.1.16",
     "npm:@tailwindcss/vite@^4.1.12": "4.1.16_vite@7.1.12__@types+node@24.9.2__picomatch@4.0.3_@types+node@24.9.2",
@@ -736,9 +736,6 @@
         "@jridgewell/resolve-uri",
         "@jridgewell/sourcemap-codec"
       ]
-    },
-    "@mjackson/node-fetch-server@0.7.0": {
-      "integrity": "sha512-un8diyEBKU3BTVj3GzlTPA1kIjCkGdD+AMYQy31Gf9JCkfoZzwgJ79GUtHrF2BN3XPNMLpubbzPcxys+a3uZEw=="
     },
     "@nodelib/fs.scandir@2.1.5": {
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
@@ -1551,6 +1548,9 @@
       "dependencies": [
         "@redis/client"
       ]
+    },
+    "@remix-run/node-fetch-server@0.12.0": {
+      "integrity": "sha512-oeg8w8aJJSuq1fCx85jCkcgTfI6On7sKwWVSO4/OW5AvTBuosAIwnuBd/LYeU/I7lYPOTW2NXhUfyfpyeexs4w=="
     },
     "@rollup/pluginutils@4.2.1": {
       "integrity": "sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==",
@@ -3894,14 +3894,14 @@
       },
       "packages/plugin-vite": {
         "dependencies": [
-          "jsr:@deno/loader@~0.3.2",
+          "jsr:@deno/loader@~0.3.10",
           "jsr:@fresh/core@2",
           "jsr:@marvinh-test/import-json@^0.0.1",
           "npm:@babel/core@^7.28.0",
           "npm:@babel/preset-react@^7.27.1",
-          "npm:@mjackson/node-fetch-server@0.7",
           "npm:@prefresh/vite@^2.4.8",
           "npm:@radix-ui/themes@^3.2.1",
+          "npm:@remix-run/node-fetch-server@0.12",
           "npm:@tailwindcss/vite@^4.1.12",
           "npm:@types/babel__core@^7.20.5",
           "npm:@types/node@^24.1.0",

--- a/deno.lock
+++ b/deno.lock
@@ -9,8 +9,8 @@
     "jsr:@deno/esbuild-plugin@^1.2.0": "1.2.0",
     "jsr:@deno/graph@0.86": "0.86.9",
     "jsr:@deno/graph@~0.82.3": "0.82.3",
-    "jsr:@deno/loader@~0.3.2": "0.3.9",
-    "jsr:@deno/loader@~0.3.3": "0.3.9",
+    "jsr:@deno/loader@~0.3.10": "0.3.10",
+    "jsr:@deno/loader@~0.3.3": "0.3.10",
     "jsr:@marvinh-test/fresh-island@^0.0.3": "0.0.3",
     "jsr:@marvinh-test/import-json@^0.0.1": "0.0.1",
     "jsr:@std/assert@^1.0.14": "1.0.15",
@@ -20,8 +20,8 @@
     "jsr:@std/async@^1.0.15": "1.0.15",
     "jsr:@std/bytes@^1.0.5": "1.0.6",
     "jsr:@std/bytes@^1.0.6": "1.0.6",
-    "jsr:@std/cli@^1.0.19": "1.0.23",
-    "jsr:@std/cli@^1.0.23": "1.0.23",
+    "jsr:@std/cli@^1.0.19": "1.0.24",
+    "jsr:@std/cli@^1.0.23": "1.0.24",
     "jsr:@std/collections@^1.1.2": "1.1.3",
     "jsr:@std/collections@^1.1.3": "1.1.3",
     "jsr:@std/crypto@^1.0.5": "1.0.5",
@@ -53,10 +53,10 @@
     "jsr:@std/media-types@1": "1.1.0",
     "jsr:@std/media-types@^1.1.0": "1.1.0",
     "jsr:@std/net@^1.0.6": "1.0.6",
-    "jsr:@std/path@1": "1.1.2",
-    "jsr:@std/path@^1.0.8": "1.1.2",
-    "jsr:@std/path@^1.1.1": "1.1.2",
-    "jsr:@std/path@^1.1.2": "1.1.2",
+    "jsr:@std/path@1": "1.1.3",
+    "jsr:@std/path@^1.0.8": "1.1.3",
+    "jsr:@std/path@^1.1.1": "1.1.3",
+    "jsr:@std/path@^1.1.2": "1.1.3",
     "jsr:@std/semver@1": "1.0.6",
     "jsr:@std/semver@^1.0.6": "1.0.6",
     "jsr:@std/streams@1": "1.0.13",
@@ -182,8 +182,8 @@
     "@deno/graph@0.86.9": {
       "integrity": "c4f353a695bcc5246c099602977dabc6534eacea9999a35a8cb24e807192e6a1"
     },
-    "@deno/loader@0.3.9": {
-      "integrity": "703d44656f7da0fa4a4a7f8a5105b5b41320821286508c2967b4252a00a2506f"
+    "@deno/loader@0.3.10": {
+      "integrity": "a9c0aa44a0499e7fecef52c29fbc206c1c8f8946388f25d9d0789a23313bfd43"
     },
     "@marvinh-test/fresh-island@0.0.3": {
       "integrity": "6d06b6009b7dfba9bba28e941e03e6ff652c4ef4f2fbfdf4b78741abd6c6c1c6",
@@ -207,8 +207,8 @@
     "@std/bytes@1.0.6": {
       "integrity": "f6ac6adbd8ccd99314045f5703e23af0a68d7f7e58364b47d2c7f408aeb5820a"
     },
-    "@std/cli@1.0.23": {
-      "integrity": "bf95b7a9425ba2af1ae5a6359daf58c508f2decf711a76ed2993cd352498ccca",
+    "@std/cli@1.0.24": {
+      "integrity": "b655a5beb26aa94f98add6bc8889f5fb9bc3ee2cc3fc954e151201f4c4200a5e",
       "dependencies": [
         "jsr:@std/internal@^1.0.12"
       ]
@@ -299,10 +299,10 @@
     "@std/net@1.0.6": {
       "integrity": "110735f93e95bb9feb95790a8b1d1bf69ec0dc74f3f97a00a76ea5efea25500c"
     },
-    "@std/path@1.1.2": {
-      "integrity": "c0b13b97dfe06546d5e16bf3966b1cadf92e1cc83e56ba5476ad8b498d9e3038",
+    "@std/path@1.1.3": {
+      "integrity": "b015962d82a5e6daea980c32b82d2c40142149639968549c649031a230b1afb3",
       "dependencies": [
-        "jsr:@std/internal@^1.0.10"
+        "jsr:@std/internal@^1.0.12"
       ]
     },
     "@std/semver@1.0.5": {

--- a/packages/plugin-vite/demo/vite.config.ts
+++ b/packages/plugin-vite/demo/vite.config.ts
@@ -11,4 +11,5 @@ export default defineConfig({
     }),
     tailwind(),
   ],
+  future: "warn",
 });

--- a/packages/plugin-vite/deno.json
+++ b/packages/plugin-vite/deno.json
@@ -25,7 +25,7 @@
     "@babel/preset-react": "npm:@babel/preset-react@^7.27.1",
     "@deno/loader": "jsr:@deno/loader@^0.3.10",
     "@marvinh-test/import-json": "jsr:@marvinh-test/import-json@^0.0.1",
-    "@mjackson/node-fetch-server": "npm:@mjackson/node-fetch-server@^0.7.0",
+    "@remix-run/node-fetch-server": "npm:@remix-run/node-fetch-server@^0.12.0",
     "@prefresh/vite": "npm:@prefresh/vite@^2.4.8",
     "@radix-ui/themes": "npm:@radix-ui/themes@^3.2.1",
     "@tailwindcss/vite": "npm:@tailwindcss/vite@^4.1.12",

--- a/packages/plugin-vite/src/mod.ts
+++ b/packages/plugin-vite/src/mod.ts
@@ -256,6 +256,6 @@ async function loadEnvFile(envPath: string) {
   try {
     await stdLoadEnv({ envPath, export: true });
   } catch {
-    // Ignoe
+    // Ignore
   }
 }

--- a/packages/plugin-vite/src/plugins/client_entry.ts
+++ b/packages/plugin-vite/src/plugins/client_entry.ts
@@ -15,7 +15,7 @@ export function clientEntryPlugin(options: ResolvedFreshViteConfig): Plugin {
       isDev = env.command === "serve";
     },
     applyToEnvironment(env) {
-      return env.name === "client";
+      return env.config.consumer === "client";
     },
     configResolved(config) {
       clientEntry = pathWithRoot(options.clientEntry, config.root);

--- a/packages/plugin-vite/src/plugins/client_snapshot.ts
+++ b/packages/plugin-vite/src/plugins/client_snapshot.ts
@@ -17,7 +17,7 @@ export function clientSnapshot(options: ResolvedFreshViteConfig): Plugin[] {
       name: "fresh:client-snapshot",
       sharedDuringBuild: true,
       applyToEnvironment(env) {
-        return env.name === "client";
+        return env.config.consumer === "client";
       },
 
       async config(cfg, env) {

--- a/packages/plugin-vite/src/plugins/deno.ts
+++ b/packages/plugin-vite/src/plugins/deno.ts
@@ -64,7 +64,9 @@ export function deno(): Plugin {
           external: true,
         };
       }
-      const loader = options?.ssr ? ssrLoader : browserLoader;
+      const loader = this.environment.config.consumer === "server"
+        ? ssrLoader
+        : browserLoader;
 
       const original = id;
 
@@ -154,8 +156,10 @@ export function deno(): Plugin {
         // ignore
       }
     },
-    async load(id, options) {
-      const loader = options?.ssr ? ssrLoader : browserLoader;
+    async load(id) {
+      const loader = this.environment.config.consumer === "server"
+        ? ssrLoader
+        : browserLoader;
 
       if (isDenoSpecifier(id)) {
         const { type, specifier } = parseDenoSpecifier(id);
@@ -168,7 +172,7 @@ export function deno(): Plugin {
         const code = new TextDecoder().decode(result.code);
 
         const maybeJsx = babelTransform({
-          ssr: !!options?.ssr,
+          ssr: this.environment.config.consumer === "server",
           media: result.mediaType,
           code,
           id: specifier,
@@ -212,7 +216,7 @@ export function deno(): Plugin {
       const code = new TextDecoder().decode(result.code);
 
       const maybeJsx = babelTransform({
-        ssr: !!options?.ssr,
+        ssr: this.environment.config.consumer === "server",
         media: result.mediaType,
         id,
         code,
@@ -230,10 +234,10 @@ export function deno(): Plugin {
       filter: {
         id: JSX_REG,
       },
-      async handler(_, id, options) {
+      async handler(_, id) {
         // This transform is a hack to be able to re-use Deno's precompile
         // jsx transform.
-        if (!options?.ssr) {
+        if (this.environment.name === "client") {
           return;
         }
 

--- a/packages/plugin-vite/src/plugins/dev_server.ts
+++ b/packages/plugin-vite/src/plugins/dev_server.ts
@@ -1,7 +1,7 @@
 import type { DevEnvironment, Plugin } from "vite";
 import * as path from "@std/path";
 import { ASSET_CACHE_BUST_KEY } from "fresh/internal";
-import { createRequest, sendResponse } from "@mjackson/node-fetch-server";
+import { createRequest, sendResponse } from "@remix-run/node-fetch-server";
 import { hashCode } from "../shared.ts";
 
 export function devServer(): Plugin[] {

--- a/packages/plugin-vite/src/plugins/dev_server.ts
+++ b/packages/plugin-vite/src/plugins/dev_server.ts
@@ -118,7 +118,7 @@ export function devServer(): Plugin[] {
     {
       name: "fresh:server_hmr",
       applyToEnvironment(env) {
-        return env.name === "ssr";
+        return env.config.consumer === "server";
       },
       hotUpdate(options) {
         const clientMod = options.server.environments.client.moduleGraph

--- a/packages/plugin-vite/src/plugins/patches.ts
+++ b/packages/plugin-vite/src/plugins/patches.ts
@@ -26,9 +26,9 @@ export function patches(): Plugin {
       filter: {
         id: JS_REG,
       },
-      handler(code, id, options) {
+      handler(code, id) {
         const presets = [];
-        if (!options?.ssr && JSX_REG.test(id)) {
+        if (this.environment.config.consumer === "client" && JSX_REG.test(id)) {
           presets.push([babelReact, {
             runtime: "automatic",
             importSource: "preact",
@@ -40,7 +40,7 @@ export function patches(): Plugin {
         const env = isDev ? "development" : "production";
 
         const plugins: babel.PluginItem[] = [
-          codeEvalPlugin(options?.ssr ? "ssr" : "client", env),
+          codeEvalPlugin(this.environment.config.consumer, env),
           cjsPlugin,
           removePolyfills,
           jsxComments,

--- a/packages/plugin-vite/src/plugins/patches/code_eval.ts
+++ b/packages/plugin-vite/src/plugins/patches/code_eval.ts
@@ -3,7 +3,7 @@ import type { PluginObj, PluginPass, types } from "@babel/core";
 const APPLY_PG_QUIRKS = "applyPgQuirks";
 
 export function codeEvalPlugin(
-  env: "ssr" | "client",
+  env: "server" | "client",
   mode: string,
 ) {
   return (
@@ -41,7 +41,7 @@ export function codeEvalPlugin(
 
 function evaluateExpr(
   t: typeof types,
-  env: "client" | "ssr",
+  env: "server" | "client",
   mode: string,
   node: types.Node,
   state: PluginPass,
@@ -76,9 +76,9 @@ function evaluateExpr(
       node.right.value === "undefined"
     ) {
       if (node.operator === "==" || node.operator === "===") {
-        return env !== "ssr";
+        return env !== "server";
       } else if (node.operator === "!=" || node.operator === "!==") {
-        return env === "ssr";
+        return env === "server";
       }
     } else if (
       // Workaround for npm:pg
@@ -125,7 +125,7 @@ function evaluateExpr(
       if (result !== null) return result;
     } else if (
       // Check: process.foo === "bar"
-      env === "ssr" && t.isMemberExpression(node.left) &&
+      env === "server" && t.isMemberExpression(node.left) &&
       t.isIdentifier(node.left.object) && node.left.object.name === "process" &&
       t.isIdentifier(node.left.property) &&
       !PROCESS_PROPERTIES.has(node.left.property.name)

--- a/packages/plugin-vite/src/plugins/patches/code_eval_test.ts
+++ b/packages/plugin-vite/src/plugins/patches/code_eval_test.ts
@@ -6,7 +6,7 @@ function runTest(
   options: {
     input: string;
     expected: string;
-    env: "client" | "ssr";
+    env: "client" | "server";
     mode: "development" | "production";
   },
 ) {
@@ -45,7 +45,7 @@ Deno.test("code eval - resolve runtime conditional detection", () => {
   });
 
   runTest({
-    env: "ssr",
+    env: "server",
     mode: "development",
     input: `if (typeof process === 'undefined') {
       module.exports = require('./browser.js');
@@ -56,7 +56,7 @@ Deno.test("code eval - resolve runtime conditional detection", () => {
   });
 
   runTest({
-    env: "ssr",
+    env: "server",
     mode: "development",
     input: `if (typeof process !== 'undefined') {
 	module.exports = require('./node.js');
@@ -93,7 +93,7 @@ Deno.test("code eval - resolve process.env.NODE_ENV", () => {
 
 Deno.test("code eval - npm:debug", () => {
   runTest({
-    env: "ssr",
+    env: "server",
     mode: "development",
     input:
       `if (typeof process === 'undefined' || process.type === 'renderer' || process.browser === true || process.__nwjs) {
@@ -107,7 +107,7 @@ Deno.test("code eval - npm:debug", () => {
 
 Deno.test("code eval - npm:pg", () => {
   runTest({
-    env: "ssr",
+    env: "server",
     mode: "development",
     input: `if (typeof process.env.NODE_PG_FORCE_NATIVE !== "undefined") {
 	module.exports = require('./native.js');
@@ -120,7 +120,7 @@ Deno.test("code eval - npm:pg", () => {
 
 Deno.test("code eval - npm:pg #2", () => {
   runTest({
-    env: "ssr",
+    env: "server",
     mode: "development",
     input:
       `const useLegacyCrypto = parseInt(process.versions && process.versions.node && process.versions.node.split('.')[0]) < 15

--- a/packages/plugin-vite/src/plugins/server_entry.ts
+++ b/packages/plugin-vite/src/plugins/server_entry.ts
@@ -34,7 +34,7 @@ export function serverEntryPlugin(
     name: "fresh:server_entry",
     sharedDuringBuild: true,
     applyToEnvironment(env) {
-      return env.name === "ssr";
+      return env.config.consumer === "server";
     },
     config(_, env) {
       isDev = env.command === "serve";
@@ -77,7 +77,7 @@ export function serverEntryPlugin(
         });
 
         code += `
-      
+
 export function registerStaticFile(prepared) {
   snapshot.staticFiles.set(prepared.name, {
     name: prepared.name,

--- a/packages/plugin-vite/src/plugins/server_snapshot.ts
+++ b/packages/plugin-vite/src/plugins/server_snapshot.ts
@@ -48,7 +48,7 @@ export function serverSnapshot(options: ResolvedFreshViteConfig): Plugin[] {
       name: "fresh:server-snapshot",
       sharedDuringBuild: true,
       applyToEnvironment(env) {
-        return env.name === "ssr";
+        return env.config.consumer === "server";
       },
       config(_, env) {
         isDev = env.command === "serve";
@@ -348,7 +348,7 @@ export function serverSnapshot(options: ResolvedFreshViteConfig): Plugin[] {
         filter: {
           id: /\.(css|less|sass|scss)(\?.*)?$/,
         },
-        handler(_code, id, _options) {
+        handler(_code, id) {
           if (server) {
             const ssrGraph = server.environments.ssr.moduleGraph;
             const mod = ssrGraph.getModuleById(id);
@@ -452,7 +452,7 @@ export default ${JSON.stringify(route.css)}
       name: "fresh-route-css-build-ssr",
       sharedDuringBuild: true,
       applyToEnvironment(env) {
-        return env.name === "ssr";
+        return env.config.consumer === "server";
       },
       async writeBundle(_, bundle) {
         const asset = bundle[".vite/manifest.json"];


### PR DESCRIPTION
I was perusing the code whilst investigating #3606 and noticed that, despite the release post claiming that Fresh had ["fully embrace[d]"](https://deno.com/blog/fresh-and-vite#:~:text=fully%20embraces) the Vite Environment API, it was still using `ssrLoadModule`. Once I started looking, I noticed a bunch of other code that wasn't future-proof (env-wise, not rolldown-wise, which'll bring it's own swath of deprecations[^1]), so I updated them as well.

The newly added source map tests from #3624 currently fail again because the ModuleRunner API at the heart of the Environment API relies on [`process.setSourceMapsEnabled`](https://docs.deno.com/api/node/process/~/Process.setSourceMapsEnabled), which is [currently set to no-op](https://github.com/denoland/deno/pull/22993) in Deno.

[^1]: Separately tried to try out rolldown-vite but it seems that Deno doesn't support aliasing dependencies whatsoever? (I know there's not official support, but I was going to try to edit the lockfile to hack around it; however, it seems that there's not alias support in there at all?)