### PR TITLE
fix: handle paths with whitespaces in staticFiles

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -3794,7 +3794,7 @@
     "https://deno.land/x/imagescript@1.3.0/v2/ops/resize.mjs": "814e78ebce8eaf8f1f918688db7b52a141405e06a36ed4b25d04413d69e7d17b",
     "https://deno.land/x/imagescript@1.3.0/v2/ops/rotate.mjs": "a1b65616717bd2eed8db406affea3263b4674dada46b56441ef38167a187455d",
     "https://deno.land/x/imagescript@1.3.0/v2/util/mem.mjs": "4968d400dae069b4bf0ef4767c1802fd2cc7d15d90eda4cfadf5b4cd19b96c6d",
-    "https://esm.sh/@docsearch/js@3.5.2/es2020/js.mjs": "9b278cf3c0b26feded7d8efeac8e2b50f76bbafcf173a95002944bcc3482830a",
+    "https://esm.sh/@docsearch/js@3.5.2/es2020/js.mjs": "964600b3c133bccfa6a5ffa240e8272a08eeff22f5fea6993aa085cfc9e4d750",
     "https://esm.sh/@docsearch/js@3.5.2?target=es2020": "4bad084f771a1923fe042ece62a9078f482f8642cb0b1acb890905e58586fee7",
     "https://raw.githubusercontent.com/denoland/ga4/main/mod.ts": "36f72ba1c90b5ebdb811427f367cd95fa6772d2de2fb45d6e57550501ee6d476",
     "https://raw.githubusercontent.com/denoland/std/refs/heads/main/_tools/check_docs.ts": "e0bf3d0ddbea93e769f0ad24f16ef2c42311c489165c9e0de9d0876d0411ffdc",

--- a/packages/fresh/src/dev/dev_build_cache.ts
+++ b/packages/fresh/src/dev/dev_build_cache.ts
@@ -529,21 +529,10 @@ ${serializedFsRoutes}
 `.replaceAll(/\n[\n]+/g, "\n\n");
 }
 
-export function systemPathToUrlEncoded(systemPath: string) {
-  const normalizedPath = systemPath.replaceAll(WINDOWS_SEPARATOR, "/");
-
-  const pathComponents = normalizedPath.split("/").filter((comp) => comp);
-
-  const encodedComponents = pathComponents.map((comp) =>
-    encodeURIComponent(comp)
-  );
-
-  const encodePath = "/" + encodedComponents.join("/");
-
-  return new URL(
-    encodePath,
-    "http://localhost",
-  ).pathname;
+export function systemPathToUrlEncoded(systemPath: string): string {
+  const normalized = systemPath.replaceAll(WINDOWS_SEPARATOR, "/");
+  const components = normalized.split("/").filter((comp) => comp);
+  return "/" + components.map((comp) => encodeURIComponent(comp)).join("/");
 }
 
 export async function prepareStaticFile(
@@ -554,11 +543,10 @@ export async function prepareStaticFile(
 > {
   const file = await Deno.open(item.filePath);
   const hash = item.hash ? item.hash : await hashContent(file.readable);
-  // fix issues[#3657]: system path convert to uri path, only new URL will convert `test %20encodeUri` to `test%20%20encodeUri`
-  const urlEncodePath = systemPathToUrlEncoded(item.pathname);
+  const encodedPathname = systemPathToUrlEncoded(item.pathname);
 
   return {
-    name: urlEncodePath,
+    name: encodedPathname,
     hash,
     filePath: path.isAbsolute(item.filePath)
       ? path.relative(outDir, item.filePath)

--- a/packages/fresh/src/middlewares/static_files.ts
+++ b/packages/fresh/src/middlewares/static_files.ts
@@ -18,7 +18,8 @@ export function staticFiles<T>(): Middleware<T> {
     const buildCache = getBuildCache(ctx);
     if (buildCache === null) return await ctx.next();
 
-    let pathname = decodeURIComponent(url.pathname);
+    // fix issues[#3657]: because build staticFiles use Url encode the path
+    let pathname = url.pathname;
     if (config.basePath) {
       pathname = pathname !== config.basePath
         ? pathname.slice(config.basePath.length)

--- a/packages/fresh/src/middlewares/static_files.ts
+++ b/packages/fresh/src/middlewares/static_files.ts
@@ -18,7 +18,6 @@ export function staticFiles<T>(): Middleware<T> {
     const buildCache = getBuildCache(ctx);
     if (buildCache === null) return await ctx.next();
 
-    // fix issues[#3657]: because build staticFiles use Url encode the path
     let pathname = url.pathname;
     if (config.basePath) {
       pathname = pathname !== config.basePath

--- a/packages/fresh/src/middlewares/static_files_test.ts
+++ b/packages/fresh/src/middlewares/static_files_test.ts
@@ -226,26 +226,17 @@ Deno.test("static files - enables caching in production", async () => {
   );
 });
 
-Deno.test("static files - decoded pathname", async () => {
-  const fileKeys = [
-    "C#.svg",
-    "西安市.png",
-    "인천.avif",
-    "/开头分隔符",
-    "\\windows\\EndSplit\\",
-  ];
-
-  // Simulate build
-  const entries = await Promise.all(
-    fileKeys.map((key) => {
-      const encodedKey = systemPathToUrlEncoded(key);
-      return [encodedKey, { content: "body {}", hash: null }];
-    }),
+Deno.test("static files - encoded pathname", async () => {
+  // Build cache stores URL-encoded paths (matching what prepareStaticFile produces)
+  const fileKeys = ["C#.svg", "西安市.png", "인천.avif"];
+  const entries = Object.fromEntries(
+    fileKeys.map((key) => [
+      systemPathToUrlEncoded(key),
+      { content: "body {}", hash: null },
+    ]),
   );
 
-  const buildCache = new MockBuildCache(
-    Object.fromEntries(entries),
-  );
+  const buildCache = new MockBuildCache(entries);
   const server = serveMiddleware(
     staticFiles(),
     { buildCache },
@@ -256,8 +247,6 @@ Deno.test("static files - decoded pathname", async () => {
       "C%23.svg",
       "%E8%A5%BF%E5%AE%89%E5%B8%82.png",
       "%EC%9D%B8%EC%B2%9C.avif",
-      "%E5%BC%80%E5%A4%B4%E5%88%86%E9%9A%94%E7%AC%A6",
-      "windows/EndSplit",
     ]
   ) {
     const res = await server.get("/" + path);

--- a/packages/plugin-vite/demo/static/test %20encodeUri/foo %20encodeUri.txt
+++ b/packages/plugin-vite/demo/static/test %20encodeUri/foo %20encodeUri.txt
@@ -1,0 +1,1 @@
+space it works

--- a/packages/plugin-vite/demo/static/test %20encodeUri/index.html
+++ b/packages/plugin-vite/demo/static/test %20encodeUri/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Document</title>
+  </head>
+  <body>
+    <h1>ok</h1>
+  </body>
+</html>

--- a/packages/plugin-vite/src/plugins/dev_server.ts
+++ b/packages/plugin-vite/src/plugins/dev_server.ts
@@ -43,8 +43,15 @@ export function devServer(): Plugin[] {
             return next();
           }
 
+          const decodePathName: string = decodeURIComponent(
+            url.pathname.slice(1),
+          );
+
           // Check if it's a static file first
-          const staticFilePath = path.join(publicDir, url.pathname.slice(1));
+          const staticFilePath = path.join(
+            publicDir,
+            decodePathName,
+          );
           try {
             const stat = await Deno.stat(staticFilePath);
             if (stat.isFile) {
@@ -57,7 +64,7 @@ export function devServer(): Plugin[] {
           // Check if it's a static/index.html file
           const staticFilePathIndex = path.join(
             publicDir,
-            url.pathname.slice(1),
+            decodePathName,
             "index.html",
           );
           try {

--- a/packages/plugin-vite/src/plugins/dev_server.ts
+++ b/packages/plugin-vite/src/plugins/dev_server.ts
@@ -43,15 +43,10 @@ export function devServer(): Plugin[] {
             return next();
           }
 
-          const decodePathName: string = decodeURIComponent(
-            url.pathname.slice(1),
-          );
+          const decodedPathname = decodeURIComponent(url.pathname.slice(1));
 
           // Check if it's a static file first
-          const staticFilePath = path.join(
-            publicDir,
-            decodePathName,
-          );
+          const staticFilePath = path.join(publicDir, decodedPathname);
           try {
             const stat = await Deno.stat(staticFilePath);
             if (stat.isFile) {
@@ -64,7 +59,7 @@ export function devServer(): Plugin[] {
           // Check if it's a static/index.html file
           const staticFilePathIndex = path.join(
             publicDir,
-            decodePathName,
+            decodedPathname,
             "index.html",
           );
           try {

--- a/packages/plugin-vite/tests/build_test.ts
+++ b/packages/plugin-vite/tests/build_test.ts
@@ -53,6 +53,13 @@ Deno.test({
         const res = await fetch(`${address}/test_static/foo.txt`);
         const text = await res.text();
         expect(text).toEqual("it works");
+
+        // test space
+        const resWithSpace = await fetch(
+          `${address}/test%20%2520encodeUri/foo%20%2520encodeUri.txt`,
+        );
+        const textWithSpace = await resWithSpace.text();
+        expect(textWithSpace).toEqual("space it works");
       },
     );
   },
@@ -482,6 +489,11 @@ Deno.test({
         const res = await fetch(`${address}/test_static/foo`);
         const text = await res.text();
         expect(text).toContain("<h1>ok</h1>");
+
+        //test encodeUri
+        const resWithSpace = await fetch(`${address}/test%20%2520encodeUri`);
+        const textWithSpace = await resWithSpace.text();
+        expect(textWithSpace).toContain("<h1>ok</h1>");
       },
     );
   },

--- a/packages/plugin-vite/tests/build_test.ts
+++ b/packages/plugin-vite/tests/build_test.ts
@@ -54,7 +54,6 @@ Deno.test({
         const text = await res.text();
         expect(text).toEqual("it works");
 
-        // test space
         const resWithSpace = await fetch(
           `${address}/test%20%2520encodeUri/foo%20%2520encodeUri.txt`,
         );
@@ -490,7 +489,6 @@ Deno.test({
         const text = await res.text();
         expect(text).toContain("<h1>ok</h1>");
 
-        //test encodeUri
         const resWithSpace = await fetch(`${address}/test%20%2520encodeUri`);
         const textWithSpace = await resWithSpace.text();
         expect(textWithSpace).toContain("<h1>ok</h1>");

--- a/packages/plugin-vite/tests/dev_server_test.ts
+++ b/packages/plugin-vite/tests/dev_server_test.ts
@@ -37,6 +37,13 @@ Deno.test({
     const res = await fetch(`${demoServer.address()}/test_static/foo.txt`);
     const text = await res.text();
     expect(text).toContain("it works");
+
+    // test space
+    const resWithSpace = await fetch(
+      `${demoServer.address()}/test%20%2520encodeUri/foo%20%2520encodeUri.txt`,
+    );
+    const textWithSpace = await resWithSpace.text();
+    expect(textWithSpace).toContain("space it works");
   },
   sanitizeResources: false,
   sanitizeOps: false,
@@ -481,6 +488,12 @@ Deno.test({
     const res = await fetch(`${demoServer.address()}/test_static/foo`);
     const text = await res.text();
     expect(text).toContain("<h1>ok</h1>");
+
+    const resWithSpace = await fetch(
+      `${demoServer.address()}/test%20%2520encodeUri/`,
+    );
+    const textWithSpace = await resWithSpace.text();
+    expect(textWithSpace).toContain("<h1>ok</h1>");
   },
   sanitizeOps: false,
   sanitizeResources: false,

--- a/packages/plugin-vite/tests/dev_server_test.ts
+++ b/packages/plugin-vite/tests/dev_server_test.ts
@@ -38,7 +38,6 @@ Deno.test({
     const text = await res.text();
     expect(text).toContain("it works");
 
-    // test space
     const resWithSpace = await fetch(
       `${demoServer.address()}/test%20%2520encodeUri/foo%20%2520encodeUri.txt`,
     );


### PR DESCRIPTION
Fix [#3657](https://github.com/denoland/fresh/issues/3657)

Static files with special characters in their names (spaces, `#`, unicode, etc.) fail to load due to path encoding issues.

## Root cause

`prepareStaticFile()` uses `new URL(pathname, base)` to normalize paths, but `new URL` doesn't properly encode characters that are already percent-encoded in the filesystem path. For example, a file literally named `test %20encodeUri` becomes `test%20%20encodeUri` (the space and literal `%20` are indistinguishable), instead of the correct `test%20%2520encodeUri`.

## Changes

### `fresh-build` (`dev_build_cache.ts`)
- Add `systemPathToUrlEncoded()` that splits the path into components and encodes each with `encodeURIComponent()`, correctly handling characters that look like percent-encoding in filenames.
- Use it in `prepareStaticFile()` instead of `new URL()`.

### `fresh` static middleware (`static_files.ts`)
- Remove `decodeURIComponent()` from the pathname lookup — the build cache now stores URL-encoded paths, so the incoming `url.pathname` (already encoded) matches directly.

### `fresh-vite-plugin` (`dev_server.ts`)
- Add `decodeURIComponent()` when resolving URL paths to filesystem paths in the dev server, so files with special characters can be found on disk.

### Tests
- Update static file tests to use `systemPathToUrlEncoded()` when building the mock cache, matching the real build flow.
- Add integration tests for files with spaces in both dev and production modes.