### PR TITLE
fix: change redirect default status from 302 to 307

### DIFF
--- a/packages/fresh/src/context.ts
+++ b/packages/fresh/src/context.ts
@@ -165,7 +165,7 @@ export class Context<State> {
    * ctx.redirect("//evil.com/");
    * ```
    */
-  redirect(pathOrUrl: string, status = 302): Response {
+  redirect(pathOrUrl: string, status = 307): Response {
     let location = pathOrUrl;
 
     // Disallow protocol relative URLs

--- a/packages/fresh/src/context_test.tsx
+++ b/packages/fresh/src/context_test.tsx
@@ -7,24 +7,27 @@ import { BUILD_ID } from "@fresh/build-id";
 import { parseHtml } from "../tests/test_utils.tsx";
 
 Deno.test("FreshReqContext.prototype.redirect", () => {
+  // Default status is now 307 to preserve HTTP method on redirect
+  // See: https://github.com/denoland/fresh/issues/2632
   let res = Context.prototype.redirect("/");
-  expect(res.status).toEqual(302);
+  expect(res.status).toEqual(307);
   expect(res.headers.get("Location")).toEqual("/");
 
   res = Context.prototype.redirect("//evil.com");
-  expect(res.status).toEqual(302);
+  expect(res.status).toEqual(307);
   expect(res.headers.get("Location")).toEqual("/evil.com");
 
   res = Context.prototype.redirect("//evil.com/foo//bar");
-  expect(res.status).toEqual(302);
+  expect(res.status).toEqual(307);
   expect(res.headers.get("Location")).toEqual("/evil.com/foo/bar");
 
   res = Context.prototype.redirect("https://deno.com");
-  expect(res.status).toEqual(302);
+  expect(res.status).toEqual(307);
   expect(res.headers.get("Location")).toEqual("https://deno.com");
 
-  res = Context.prototype.redirect("/", 307);
-  expect(res.status).toEqual(307);
+  // Explicit 302 still works for backward compatibility
+  res = Context.prototype.redirect("/", 302);
+  expect(res.status).toEqual(302);
 });
 
 Deno.test("render asset()", async () => {


### PR DESCRIPTION
## Summary
Changes the default redirect status code from 302 to 307 to preserve the original HTTP method on redirect.

This fixes POST redirects being converted to GET requests when using basepath configuration.

## Problem
Per RFC 7231:
- **302 Found**: User agents MAY change the request method (browsers convert POST→GET)
- **307 Temporary Redirect**: Method and body MUST NOT be changed

The current default of 302 breaks form submissions when redirecting, as POST requests become GET requests.

## Solution
Change the default status in `ctx.redirect()` from 302 to 307.

Users who explicitly need 302 behavior can still pass it:
```ts
ctx.redirect("/path", 302)
```

## Test plan
- Updated existing redirect tests to expect 307 as default
- Added test verifying explicit 302 still works for backward compatibility

Fixes #2632

🤖 Generated with [Claude Code](https://claude.ai/code)