### PR TITLE
Fix typo in getting started documentation

### DIFF
--- a/docs/latest/getting-started/index.md
+++ b/docs/latest/getting-started/index.md
@@ -12,7 +12,7 @@ command:
 deno run -Ar jsr:@fresh/init
 ```
 
-This will span a short wizard that guides you through the setup, like the
+This will spawn a short wizard that guides you through the setup, like the
 project name, if you want to use tailwindcss and if you're using vscode. Your
 project folder should look like this:
 


### PR DESCRIPTION
Corrected the typo 'span' to 'spawn' in the setup instructions.