### PR TITLE
ci: use canary Deno version for JSR publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,6 +22,7 @@ jobs:
         uses: denoland/setup-deno@v2
         with:
           cache: true
+          deno-version: canary
 
       - name: Install dependencies
         run: deno install


### PR DESCRIPTION
Mostly to quickly get updates and fixes like https://github.com/denoland/deno/pull/32127