### PR TITLE
fix: preserve partial search param through redirects

### DIFF
--- a/packages/fresh/src/context.ts
+++ b/packages/fresh/src/context.ts
@@ -182,6 +182,16 @@ export class Context<State> {
       location = `${pathname.replaceAll(/\/+/g, "/")}${search}`;
     }
 
+    // Preserve the partial search param through redirects so that the
+    // redirected page is still rendered in partial mode.
+    if (this.isPartial) {
+      const hashIdx = location.indexOf("#");
+      const base = hashIdx > -1 ? location.slice(0, hashIdx) : location;
+      const hash = hashIdx > -1 ? location.slice(hashIdx) : "";
+      const separator = base.includes("?") ? "&" : "?";
+      location = `${base}${separator}${PARTIAL_SEARCH_PARAM}=true${hash}`;
+    }
+
     return new Response(null, {
       status,
       headers: {

--- a/packages/fresh/src/context_test.tsx
+++ b/packages/fresh/src/context_test.tsx
@@ -70,6 +70,44 @@ Deno.test("ctx.render - throw with invalid first arg", async () => {
   expect(res.status).toEqual(500);
 });
 
+Deno.test("ctx.redirect - preserves partial search param through redirects", async () => {
+  const app = new App()
+    .get("/old", (ctx) => ctx.redirect("/new"));
+  const server = new FakeServer(app.handler());
+
+  // Normal redirect should not have partial param
+  let res = await server.get("/old");
+  expect(res.status).toEqual(302);
+  expect(res.headers.get("Location")).toEqual("/new");
+
+  // Partial redirect should preserve the param
+  res = await server.get("/old?fresh-partial=true");
+  expect(res.status).toEqual(302);
+  expect(res.headers.get("Location")).toEqual("/new?fresh-partial=true");
+
+  // Partial redirect with existing query params
+  const app2 = new App()
+    .get("/old", (ctx) => ctx.redirect("/new?foo=bar"));
+  const server2 = new FakeServer(app2.handler());
+
+  res = await server2.get("/old?fresh-partial=true");
+  expect(res.status).toEqual(302);
+  expect(res.headers.get("Location")).toEqual(
+    "/new?foo=bar&fresh-partial=true",
+  );
+
+  // Partial redirect with hash fragment — param must come before the hash
+  const app3 = new App()
+    .get("/old", (ctx) => ctx.redirect("/new#section"));
+  const server3 = new FakeServer(app3.handler());
+
+  res = await server3.get("/old?fresh-partial=true");
+  expect(res.status).toEqual(302);
+  expect(res.headers.get("Location")).toEqual(
+    "/new?fresh-partial=true#section",
+  );
+});
+
 Deno.test("ctx.isPartial - should indicate whether request is partial or not", async () => {
   const isPartials: boolean[] = [];
   const app = new App()


### PR DESCRIPTION
## Summary
- Fixes #2610 — "Partial + redirect breaks islands"
- When a partial request (`?fresh-partial=true`) hits a server-side redirect via `ctx.redirect()`, the `fresh-partial` search param is now preserved in the redirect `Location` header
- Previously the param was lost, so the redirect target rendered as a full page instead of a partial response, breaking island hydration

The fix is in `ctx.redirect()` in `packages/fresh/src/context.ts` — when `this.isPartial` is true, the partial param is appended to the redirect location (handling existing query params and hash fragments correctly).

## Test plan
- [x] New test: `ctx.redirect - preserves partial search param through redirects`
  - Normal redirect does not add param
  - Partial redirect preserves param
  - Partial redirect with existing query params uses `&`
  - Partial redirect with hash fragment places param before `#`
- [x] All existing context tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)