### PR TITLE
fix: fall back to full navigation when partial redirect has no partials

### DIFF
--- a/packages/fresh/src/runtime/client/partials.ts
+++ b/packages/fresh/src/runtime/client/partials.ts
@@ -301,7 +301,17 @@ async function fetchPartials(
     maybeUpdateHistory(actualUrl);
   }
 
-  await applyPartials(res);
+  try {
+    await applyPartials(res);
+  } catch (err) {
+    // When a redirect leads to a page without partials, fall back
+    // to a full page navigation instead of silently failing.
+    if (err instanceof NoPartialsError && res.redirected) {
+      location.href = actualUrl.href;
+      return;
+    }
+    throw err;
+  }
 }
 
 interface PartialReviveCtx {

--- a/packages/fresh/src/runtime/client/partials.ts
+++ b/packages/fresh/src/runtime/client/partials.ts
@@ -297,10 +297,6 @@ async function fetchPartials(
     }
   }
 
-  if (shouldNavigate) {
-    maybeUpdateHistory(actualUrl);
-  }
-
   try {
     await applyPartials(res);
   } catch (err) {
@@ -311,6 +307,10 @@ async function fetchPartials(
       return;
     }
     throw err;
+  }
+
+  if (shouldNavigate) {
+    maybeUpdateHistory(actualUrl);
   }
 }
 


### PR DESCRIPTION
## Summary
- Fixes #2560 — "Inside `f-partial-nav` the server-side redirects do not work"
- Related to #2610 (fixed in #3715)

When a form POST (or link click) within `f-client-nav` results in a server-side redirect to a page that **doesn't have any `<Partial>` components**, the client now falls back to a full-page navigation (`location.href`) instead of silently doing nothing.

### The problem
1. Form with `f-partial="/routes/submit"` submits a POST
2. Server handler returns a 301/302 redirect to `/another-place`
3. Client follows the redirect, gets a full HTML page with no `<Partial>` markers
4. `applyPartials()` throws `NoPartialsError` — **unhandled** in click/submit handlers
5. Nothing happens visually; the user is stuck

### The fix
`fetchPartials()` now catches `NoPartialsError` internally. When the response was a redirect (`res.redirected`) and no partials were found, it falls back to `location.href = actualUrl.href` for a full-page navigation. Non-redirect `NoPartialsError` cases still propagate (the popstate handler already catches those for back-button navigation).

## Test plan
- [x] Lint/format clean
- [ ] Manual test: form with `f-partial` that redirects to a non-partial page should navigate correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)