### PR TITLE
chore: release 2.2.2

### DIFF
--- a/packages/fresh/deno.json
+++ b/packages/fresh/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@fresh/core",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "license": "MIT",
   "exports": {
     ".": "./src/mod.ts",

--- a/packages/init/src/init.ts
+++ b/packages/init/src/init.ts
@@ -5,7 +5,7 @@ import * as semver from "@std/semver";
 import initConfig from "../deno.json" with { type: "json" };
 
 // Keep these as is, as we replace these version in our release script
-const FRESH_VERSION = "2.2.1";
+const FRESH_VERSION = "2.2.2";
 const FRESH_TAILWIND_VERSION = "1.0.0";
 const FRESH_VITE_PLUGIN = "1.0.0";
 const PREACT_VERSION = "10.28.3";

--- a/packages/update/deno.json
+++ b/packages/update/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@fresh/update",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "license": "MIT",
   "exports": "./src/mod.ts",
   "exclude": ["**/tmp/*"],

--- a/packages/update/src/update.ts
+++ b/packages/update/src/update.ts
@@ -7,7 +7,7 @@ import { walk } from "@std/fs/walk";
 
 export const SyntaxKind = tsmorph.ts.SyntaxKind;
 
-export const FRESH_VERSION = "2.2.1";
+export const FRESH_VERSION = "2.2.2";
 export const PREACT_VERSION = "10.28.3";
 export const PREACT_SIGNALS_VERSION = "2.7.1";
 


### PR DESCRIPTION
## Summary
- Bump version from 2.2.1 to 2.2.2 across all packages (@fresh/core, @fresh/update, @fresh/init)
- v2.2.1 was tagged but never actually published to JSR, causing users to be prompted to upgrade to a non-existent version

Closes #3683