### PR TITLE
fix: improve error message for missing exports in file routes

### DIFF
--- a/packages/fresh/src/fs_routes.ts
+++ b/packages/fresh/src/fs_routes.ts
@@ -310,8 +310,11 @@ export function validateFsMod<State>(
   mod: FreshFsMod<State>;
 } {
   if (!isFreshFile<State>(mod, commandType)) {
+    const hint = commandType === CommandType.Middleware
+      ? `Middleware files must have a default export (function or array of functions).\n\n  Example:\n    export default define.middleware(async (ctx) => {\n      return await ctx.next();\n    });`
+      : `Route files must export a default component, a "handler" or "handlers" export, or a "config" export.\n\n  Example:\n    export const handler = define.handlers({ GET(ctx) { ... } });\n    export default define.page((props) => <h1>Hello</h1>);`;
     throw new Error(
-      `Expected a route, middleware, layout or error template, but couldn't find relevant exports in: ${filePath}`,
+      `Could not find relevant exports in: ${filePath}\n\n${hint}`,
     );
   }
 


### PR DESCRIPTION
## Summary

- Improves the unhelpful error message when a file-system route file has no recognized exports
- Now shows specific hints based on file type (middleware vs route) with code examples

**Before:**
```
Error: Expected a route, middleware, layout or error template, but couldn't find relevant exports in: routes/_middleware.ts
```

**After (middleware):**
```
Error: Could not find relevant exports in: routes/_middleware.ts

Middleware files must have a default export (function or array of functions).

  Example:
    export default define.middleware(async (ctx) => {
      return await ctx.next();
    });
```

**After (route):**
```
Error: Could not find relevant exports in: routes/api/users.ts

Route files must export a default component, a "handler" or "handlers" export, or a "config" export.

  Example:
    export const handler = define.handlers({ GET(ctx) { ... } });
    export default define.page((props) => <h1>Hello</h1>);
```

## Test plan

- [x] `deno test -A packages/fresh/src/fs_routes_test.tsx` — 55 passed

Closes #3652

🤖 Generated with [Claude Code](https://claude.com/claude-code)