### PR TITLE
fix: resolve server entry filename from bundle chunks

### DIFF
--- a/packages/plugin-vite/src/plugins/server_entry.ts
+++ b/packages/plugin-vite/src/plugins/server_entry.ts
@@ -123,7 +123,6 @@ if (import.meta.hot) import.meta.hot.accept();`;
         const json = JSON.parse(manifest.source) as Manifest;
 
         for (const item of Object.values(json)) {
-
           if (item.assets) {
             for (let i = 0; i < item.assets.length; i++) {
               const id = item.assets[i];

--- a/packages/plugin-vite/src/plugins/server_entry.ts
+++ b/packages/plugin-vite/src/plugins/server_entry.ts
@@ -103,6 +103,16 @@ if (import.meta.hot) import.meta.hot.accept();`;
       },
     },
     async writeBundle(_options, bundle) {
+      // Find server entry filename directly from bundle chunks.
+      // This is more reliable than the manifest when rollupOptions
+      // override output.entryFileNames.
+      for (const chunk of Object.values(bundle)) {
+        if (chunk.type === "chunk" && chunk.isEntry) {
+          serverEntryFilename = chunk.fileName;
+          break;
+        }
+      }
+
       const manifest = bundle[".vite/manifest.json"];
 
       const staticFiles: PendingStaticFile[] = [];
@@ -113,9 +123,6 @@ if (import.meta.hot) import.meta.hot.accept();`;
         const json = JSON.parse(manifest.source) as Manifest;
 
         for (const item of Object.values(json)) {
-          if (item.isEntry) {
-            serverEntryFilename = item.file;
-          }
 
           if (item.assets) {
             for (let i = 0; i < item.assets.length; i++) {


### PR DESCRIPTION
## Summary
- When users customize `rollupOptions.output.entryFileNames` in their vite config, the server entry file gets renamed but the generated `server.js` still tried to import `"./server/server-entry.mjs"` (the hardcoded fallback)
- Fix: read the entry filename directly from the Vite bundle chunks instead of relying on the manifest, which always reflects the actual output filename

Closes #3655

## Test plan
- [ ] Create a fresh project, set `rollupOptions.output.entryFileNames` to a custom value (e.g. `abc.js`), run `deno task build && deno task start` — server should start without "Module not found" error
- [ ] Default config (no custom `entryFileNames`) still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)