### PR TITLE
fix: don't intercept forms without explicit f-partial inside f-client-nav

### DIFF
--- a/packages/fresh/src/runtime/client/partials.ts
+++ b/packages/fresh/src/runtime/client/partials.ts
@@ -233,7 +233,8 @@ document.addEventListener("submit", async (e) => {
 
     const hasExplicitPartial = e.submitter?.hasAttribute(PARTIAL_ATTR) ||
       e.submitter?.hasAttribute("formaction") ||
-      el.hasAttribute(PARTIAL_ATTR);
+      el.hasAttribute(PARTIAL_ATTR) ||
+      el.hasAttribute("action");
 
     const rawPartialUrl = e.submitter?.getAttribute(PARTIAL_ATTR) ??
       e.submitter?.getAttribute("formaction") ??
@@ -241,9 +242,9 @@ document.addEventListener("submit", async (e) => {
     const rawActionUrl = e.submitter?.getAttribute("formaction") ?? el.action;
 
     // Only intercept forms that explicitly opt in to partial navigation
-    // via f-partial or formaction. Without this check, every form inside
-    // f-client-nav would be intercepted because el.action is always
-    // non-empty (defaults to the current URL).
+    // via f-partial, formaction, or an explicit action attribute. Without
+    // this check, every form inside f-client-nav would be intercepted
+    // because el.action is always non-empty (defaults to the current URL).
     if (hasExplicitPartial && rawPartialUrl !== "") {
       e.preventDefault();
 

--- a/packages/fresh/src/runtime/client/partials.ts
+++ b/packages/fresh/src/runtime/client/partials.ts
@@ -231,12 +231,20 @@ document.addEventListener("submit", async (e) => {
       return;
     }
 
+    const hasExplicitPartial = e.submitter?.hasAttribute(PARTIAL_ATTR) ||
+      e.submitter?.hasAttribute("formaction") ||
+      el.hasAttribute(PARTIAL_ATTR);
+
     const rawPartialUrl = e.submitter?.getAttribute(PARTIAL_ATTR) ??
       e.submitter?.getAttribute("formaction") ??
       el.getAttribute(PARTIAL_ATTR) ?? el.action;
     const rawActionUrl = e.submitter?.getAttribute("formaction") ?? el.action;
 
-    if (rawPartialUrl !== "") {
+    // Only intercept forms that explicitly opt in to partial navigation
+    // via f-partial or formaction. Without this check, every form inside
+    // f-client-nav would be intercepted because el.action is always
+    // non-empty (defaults to the current URL).
+    if (hasExplicitPartial && rawPartialUrl !== "") {
       e.preventDefault();
 
       const partialUrl = new URL(rawPartialUrl, location.href);

--- a/packages/fresh/tests/partials_test.tsx
+++ b/packages/fresh/tests/partials_test.tsx
@@ -1858,6 +1858,46 @@ Deno.test({
 });
 
 Deno.test({
+  name: "partials - form without action inside f-client-nav not intercepted",
+  fn: async () => {
+    const app = testApp()
+      .post("/", (ctx) => {
+        return ctx.render(
+          <Doc>
+            <p class="submitted">form submitted normally</p>
+          </Doc>,
+        );
+      })
+      .get("/", (ctx) => {
+        return ctx.render(
+          <Doc>
+            <div f-client-nav>
+              <form method="post">
+                <input name="name" value="foo" />
+                <Partial name="foo">
+                  <p class="init">init</p>
+                </Partial>
+                <button type="submit" class="update">
+                  update
+                </button>
+              </form>
+            </div>
+          </Doc>,
+        );
+      });
+
+    await withBrowserApp(app, async (page, address) => {
+      await page.goto(address, { waitUntil: "load" });
+      await page.locator(".init").wait();
+
+      await page.locator(".update").click();
+      // Form should do a full page navigation, not a partial update
+      await page.locator(".submitted").wait();
+    });
+  },
+});
+
+Deno.test({
   name: "partials - submit form redirect",
   fn: async () => {
     const app = testApp()

--- a/packages/fresh/tests/partials_test.tsx
+++ b/packages/fresh/tests/partials_test.tsx
@@ -1890,8 +1890,11 @@ Deno.test({
       await page.goto(address, { waitUntil: "load" });
       await page.locator(".init").wait();
 
-      await page.locator(".update").click();
       // Form should do a full page navigation, not a partial update
+      await Promise.all([
+        page.waitForNavigation(),
+        page.locator(".update").click(),
+      ]);
       await page.locator(".submitted").wait();
     });
   },


### PR DESCRIPTION
## Summary
- Fixes #3473 — "Partial 'messages' not found. Skipping..."
- Forms inside `f-client-nav` without an explicit `f-partial` attribute were being intercepted as partial requests, breaking normal form submissions

### Root cause
The form submit handler's fallback chain for determining the partial URL:
```js
const rawPartialUrl = e.submitter?.getAttribute(PARTIAL_ATTR) ??
  e.submitter?.getAttribute("formaction") ??
  el.getAttribute(PARTIAL_ATTR) ?? el.action;
```

Always falls through to `el.action`, which defaults to the current page URL for any `<form>` without an explicit `action` attribute. Since `el.action` is never empty, the `rawPartialUrl !== ""` check on the next line was always `true`, meaning **every form** inside `f-client-nav` was intercepted — even forms that never opted in to partial navigation.

This caused:
1. Normal form POSTs to be sent with `?fresh-partial=true`
2. Server rendering in partial mode, returning only `<Partial>` fragments
3. The rest of the page content being lost

### Fix
Added a `hasExplicitPartial` check that requires the form or its submitter to have an explicit `f-partial` or `formaction` attribute before intercepting. Forms without these attributes now submit normally, even inside `f-client-nav`.

## Test plan
- [x] Lint/format clean
- [ ] Manual test: form inside `f-client-nav` without `f-partial` should submit normally (full page reload)
- [ ] Manual test: form with `f-partial` inside `f-client-nav` should still work as partial navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)