### PR TITLE
fix: add @types/babel__core to vite project template

### DIFF
--- a/packages/init/src/init.ts
+++ b/packages/init/src/init.ts
@@ -616,6 +616,8 @@ if (Deno.args.includes("build")) {
     denoJson.imports["@fresh/plugin-vite"] =
       `jsr:@fresh/plugin-vite@^${vitePluginVersion}`;
     denoJson.imports["vite"] = "npm:vite@^7.1.3";
+    denoJson.imports["@types/babel__core"] =
+      "npm:@types/babel__core@^7.20.5";
 
     if (useTailwind) {
       denoJson.imports["tailwindcss"] =

--- a/packages/init/src/init.ts
+++ b/packages/init/src/init.ts
@@ -616,8 +616,7 @@ if (Deno.args.includes("build")) {
     denoJson.imports["@fresh/plugin-vite"] =
       `jsr:@fresh/plugin-vite@^${vitePluginVersion}`;
     denoJson.imports["vite"] = "npm:vite@^7.1.3";
-    denoJson.imports["@types/babel__core"] =
-      "npm:@types/babel__core@^7.20.5";
+    denoJson.imports["@types/babel__core"] = "npm:@types/babel__core@^7.20.5";
 
     if (useTailwind) {
       denoJson.imports["tailwindcss"] =


### PR DESCRIPTION
## Summary
- New projects with `nodeModulesDir: "manual"` fail `deno check` because Deno can't resolve types for `@babel/core` (imported by `@fresh/plugin-vite`)
- Fix: add `@types/babel__core` to the init template's imports so new Vite-based projects include it explicitly

Closes #3605

## Test plan
- [ ] Run `deno run -A jsr:@fresh/init`, create a new project with Vite
- [ ] Verify `@types/babel__core` appears in the generated `deno.json` imports
- [ ] Run `deno task check` / `deno check` — should pass without manually installing `@types/babel__core`

🤖 Generated with [Claude Code](https://claude.com/claude-code)