### PR TITLE
fix: apply layout to index route with programmatic routing

### DIFF
--- a/packages/fresh/src/app.ts
+++ b/packages/fresh/src/app.ts
@@ -257,7 +257,7 @@ export class App<State> {
     route: MaybeLazy<Route<State>>,
     config?: RouteConfig,
   ): this {
-    this.#commands.push(newRouteCmd(path, route, config, false));
+    this.#commands.push(newRouteCmd(path, route, config, true));
     return this;
   }
 
@@ -265,42 +265,42 @@ export class App<State> {
    * Add middlewares for GET requests at the specified path.
    */
   get(path: string, ...middlewares: MaybeLazy<Middleware<State>>[]): this {
-    this.#commands.push(newHandlerCmd("GET", path, middlewares, false));
+    this.#commands.push(newHandlerCmd("GET", path, middlewares, true));
     return this;
   }
   /**
    * Add middlewares for POST requests at the specified path.
    */
   post(path: string, ...middlewares: MaybeLazy<Middleware<State>>[]): this {
-    this.#commands.push(newHandlerCmd("POST", path, middlewares, false));
+    this.#commands.push(newHandlerCmd("POST", path, middlewares, true));
     return this;
   }
   /**
    * Add middlewares for PATCH requests at the specified path.
    */
   patch(path: string, ...middlewares: MaybeLazy<Middleware<State>>[]): this {
-    this.#commands.push(newHandlerCmd("PATCH", path, middlewares, false));
+    this.#commands.push(newHandlerCmd("PATCH", path, middlewares, true));
     return this;
   }
   /**
    * Add middlewares for PUT requests at the specified path.
    */
   put(path: string, ...middlewares: MaybeLazy<Middleware<State>>[]): this {
-    this.#commands.push(newHandlerCmd("PUT", path, middlewares, false));
+    this.#commands.push(newHandlerCmd("PUT", path, middlewares, true));
     return this;
   }
   /**
    * Add middlewares for DELETE requests at the specified path.
    */
   delete(path: string, ...middlewares: MaybeLazy<Middleware<State>>[]): this {
-    this.#commands.push(newHandlerCmd("DELETE", path, middlewares, false));
+    this.#commands.push(newHandlerCmd("DELETE", path, middlewares, true));
     return this;
   }
   /**
    * Add middlewares for HEAD requests at the specified path.
    */
   head(path: string, ...middlewares: MaybeLazy<Middleware<State>>[]): this {
-    this.#commands.push(newHandlerCmd("HEAD", path, middlewares, false));
+    this.#commands.push(newHandlerCmd("HEAD", path, middlewares, true));
     return this;
   }
 
@@ -308,7 +308,7 @@ export class App<State> {
    * Add middlewares for all HTTP verbs at the specified path.
    */
   all(path: string, ...middlewares: MaybeLazy<Middleware<State>>[]): this {
-    this.#commands.push(newHandlerCmd("ALL", path, middlewares, false));
+    this.#commands.push(newHandlerCmd("ALL", path, middlewares, true));
     return this;
   }
 

--- a/packages/fresh/src/app_test.tsx
+++ b/packages/fresh/src/app_test.tsx
@@ -824,7 +824,7 @@ Deno.test("App - .appWrapper()", async () => {
   expect(await res.text()).toContain("<body>app/index<");
 });
 
-Deno.test.ignore("App - .layout()", async () => {
+Deno.test("App - .layout()", async () => {
   const app = new App()
     .layout("/", ({ Component }) => (
       <>
@@ -840,7 +840,6 @@ Deno.test.ignore("App - .layout()", async () => {
 
   const server = new FakeServer(app.handler());
 
-  // The `/foo` layout is not applied for GET `/foo`, is that correct?
   const res = await server.get("/foo");
   expect(await res.text()).toContain("<body>layout/foo/index<");
 });


### PR DESCRIPTION
## Summary
- Fixed `.layout()` not applying to routes registered at the same path with `.get()`, `.post()`, `.route()`, etc.
- Re-enabled the previously-ignored `"App - .layout()"` test

The root cause was that `.layout("/foo", ...)` uses `includeLastSegment: true` when placing itself in the segment tree, landing on the `"foo"` segment. But `.get("/foo", ...)` used `includeLastSegment: false`, landing on the **root** segment. Since `segmentToMiddlewares()` walks **up** from the route's segment, it never reached the layout's child segment.

The fix sets `includeLastSegment: true` for all programmatic route/handler commands, matching the behavior of fs routes (which work correctly because `routes/foo/index.tsx` gets pattern `/foo/` with a trailing slash, naturally resolving to the same segment).

Closes #3553

## Test plan
- [x] Re-enabled ignored test `"App - .layout()"` — now passes
- [x] All 47 app tests pass
- [x] All router and segments tests pass
- [x] All 22 builder tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)