### PR TITLE
fix: middleware not matching routes with optional parameters in fs routing

### DIFF
--- a/packages/fresh/src/router.ts
+++ b/packages/fresh/src/router.ts
@@ -271,21 +271,27 @@ export function patternToSegments(
 
   if (path === "/" || path === "*" || path === "/*") return out;
 
+  // Strip optional groups like {/:param}? before segmenting, so that
+  // /api{/:opt}?/endpoint produces the same segments as /api/endpoint.
+  // This ensures middleware registered at /api applies to routes with
+  // optional parameters under /api.
+  const cleaned = path.replace(/\{[^}]*\}\??/g, "");
+
   let start = -1;
-  for (let i = 0; i < path.length; i++) {
-    const ch = path[i];
+  for (let i = 0; i < cleaned.length; i++) {
+    const ch = cleaned[i];
 
     if (ch === "/") {
       if (i > 0) {
-        const raw = path.slice(start + 1, i);
+        const raw = cleaned.slice(start + 1, i);
         out.push(raw);
       }
       start = i;
     }
   }
 
-  if (includeLast && start < path.length - 1) {
-    out.push(path.slice(start + 1));
+  if (includeLast && start < cleaned.length - 1) {
+    out.push(cleaned.slice(start + 1));
   }
 
   return out;

--- a/packages/fresh/src/router_test.ts
+++ b/packages/fresh/src/router_test.ts
@@ -152,6 +152,14 @@ Deno.test("patternToSegments", () => {
   expect(patternToSegments("/foo/", "")).toEqual(["", "foo"]);
 
   expect(patternToSegments("/foo/bar", "", true)).toEqual(["", "foo", "bar"]);
+
+  // Optional params with {/...}? syntax should not split on / inside braces
+  expect(patternToSegments("/api{/:opt}?/endpoint", "")).toEqual(["", "api"]);
+  expect(patternToSegments("/api{/:opt}?/endpoint", "", true)).toEqual([
+    "",
+    "api",
+    "endpoint",
+  ]);
 });
 
 Deno.test("mergePath", () => {


### PR DESCRIPTION
## Summary
- Fixed `app.use("/api", middleware)` not applying to fs routes with optional parameters like `routes/api/[[opt]]/endpoint.ts`
- The root cause was `patternToSegments()` splitting on `/` characters inside `{...}` groups in URLPattern syntax

When `routes/api/[[opt]]/endpoint.ts` is converted to the pattern `/api{/:opt}?/endpoint`, the `/` inside `{/:opt}?` was treated as a segment boundary, producing segments `["", "api{", ":opt}?"]` instead of `["", "api"]`. This caused the route to land in a different segment tree node than the middleware registered at `/api`.

The fix strips `{...}?` optional groups before segmenting, so `/api{/:opt}?/endpoint` produces the same segments as `/api/endpoint`.

Closes #3545

## Test plan
- [x] Added test cases for `patternToSegments` with `{/:opt}?` syntax
- [x] All 59 router/segments/app tests pass
- [x] All 22 builder tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)