### PR TITLE
fix: normalize Windows paths in generated snapshot and server entry

### DIFF
--- a/packages/fresh/src/dev/dev_build_cache.ts
+++ b/packages/fresh/src/dev/dev_build_cache.ts
@@ -17,6 +17,13 @@ import { contentType as getStdContentType } from "@std/media-types/content-type"
 
 const WINDOWS_SEPARATOR = pathWin32.SEPARATOR;
 
+/** Normalize a path to use forward slashes so that generated files
+ *  are portable across operating systems (e.g. build on Windows,
+ *  deploy on Linux). */
+function toPosix(p: string): string {
+  return p.replaceAll(WINDOWS_SEPARATOR, "/");
+}
+
 export interface MemoryFile {
   hash: string | null;
   contentType: string;
@@ -376,7 +383,7 @@ export class DiskBuildCache<State> implements DevBuildCache<State> {
     await Deno.writeTextFile(
       path.join(outDir, "server.js"),
       generateServerEntry({
-        root: appPath,
+        root: toPosix(appPath),
         serverEntry: pathToSpec(outDir, this.#config.serverEntry),
         snapshotSpecifier: "./snapshot.js",
       }),
@@ -548,9 +555,11 @@ export async function prepareStaticFile(
   return {
     name: encodedPathname,
     hash,
-    filePath: path.isAbsolute(item.filePath)
-      ? path.relative(outDir, item.filePath)
-      : item.filePath,
+    filePath: toPosix(
+      path.isAbsolute(item.filePath)
+        ? path.relative(outDir, item.filePath)
+        : item.filePath,
+    ),
     contentType: getContentType(item.filePath),
   };
 }
@@ -562,22 +571,24 @@ export function generateServerEntry(
     snapshotSpecifier: string;
   },
 ): string {
-  let rootPath = `path.join(import.meta.dirname, ${
-    JSON.stringify(options.root)
-  })`;
-  if (path.isAbsolute(options.root)) {
+  const root = toPosix(options.root);
+  const serverEntry = toPosix(options.serverEntry);
+  const snapshotSpecifier = toPosix(options.snapshotSpecifier);
+
+  let rootPath = `path.join(import.meta.dirname, ${JSON.stringify(root)})`;
+  if (path.isAbsolute(root)) {
     // deno-lint-ignore no-console
     console.warn(
-      `WARN: using absolute root path in snapshot: "${options.root}"`,
+      `WARN: using absolute root path in snapshot: "${root}"`,
     );
 
-    rootPath = JSON.stringify(options.root);
+    rootPath = JSON.stringify(root);
   }
 
   return `${EDIT_WARNING}
 import { setBuildCache, ProdBuildCache, path } from "fresh/internal";
-import * as snapshot from "${options.snapshotSpecifier}";
-import { app } from "${options.serverEntry}";
+import * as snapshot from "${snapshotSpecifier}";
+import { app } from "${serverEntry}";
 
 const root = ${rootPath};
 setBuildCache(app, new ProdBuildCache(root, snapshot), "production");

--- a/packages/fresh/src/dev/dev_build_cache_test.ts
+++ b/packages/fresh/src/dev/dev_build_cache_test.ts
@@ -1,5 +1,9 @@
 import { expect } from "@std/expect";
-import { MemoryBuildCache } from "./dev_build_cache.ts";
+import {
+  generateServerEntry,
+  MemoryBuildCache,
+  prepareStaticFile,
+} from "./dev_build_cache.ts";
 import { FileTransformer } from "./file_transformer.ts";
 import { createFakeFs, withTmpDir } from "../test_utils.ts";
 import type { ResolvedBuildConfig } from "./builder.ts";
@@ -43,5 +47,53 @@ Deno.test({
     await expect(noThrown2).resolves.toBe(null);
     await expect(noThrown3).resolves.toBe(null);
     await expect(noThrown4).resolves.toBe(null);
+  },
+});
+
+Deno.test("generateServerEntry - normalizes Windows paths to forward slashes", () => {
+  const output = generateServerEntry({
+    root: "..\\..\\myapp",
+    serverEntry: ".\\src\\main.ts",
+    snapshotSpecifier: ".\\snapshot.js",
+  });
+
+  // No backslashes should appear in the generated code
+  expect(output).not.toContain("\\");
+  expect(output).toContain(`from "./snapshot.js"`);
+  expect(output).toContain(`from "./src/main.ts"`);
+  expect(output).toContain(`"../../myapp"`);
+});
+
+Deno.test("generateServerEntry - forward slashes pass through unchanged", () => {
+  const output = generateServerEntry({
+    root: "../../myapp",
+    serverEntry: "./src/main.ts",
+    snapshotSpecifier: "./snapshot.js",
+  });
+
+  expect(output).not.toContain("\\");
+  expect(output).toContain(`from "./snapshot.js"`);
+  expect(output).toContain(`from "./src/main.ts"`);
+  expect(output).toContain(`"../../myapp"`);
+});
+
+Deno.test({
+  name: "prepareStaticFile - normalizes Windows filePath to forward slashes",
+  fn: async () => {
+    await using _tmp = await withTmpDir();
+    const tmp = _tmp.dir;
+
+    // Create a test file
+    const filePath = `${tmp}/assets/style.css`;
+    await Deno.mkdir(`${tmp}/assets`, { recursive: true });
+    await Deno.writeTextFile(filePath, "body {}");
+
+    const result = await prepareStaticFile(
+      { filePath, hash: null, pathname: "/assets/style.css" },
+      tmp,
+    );
+
+    expect(result.filePath).not.toContain("\\");
+    expect(result.filePath).toEqual("assets/style.css");
   },
 });


### PR DESCRIPTION
## Summary
- When building on Windows, `path.relative()` produces backslash separators (`\`) that get hardcoded into the generated `snapshot.js` and `server.js` files
- If the bundle is then deployed to a Linux server (e.g. Windows CI → Linux prod), those paths break at runtime
- Fix: add a `toPosix()` helper that normalizes all paths written into generated files to use forward slashes, applied in three places:
  - `root` path passed to `generateServerEntry()`
  - `filePath` in `prepareStaticFile()` (from `path.relative()`)
  - All path options inside `generateServerEntry()` (root, serverEntry, snapshotSpecifier)

Closes #3513

## Test plan
- [ ] Existing tests pass (`dev_build_cache_test.ts`, `utils_test.ts`)
- [ ] Build on Windows, verify generated `_fresh/server.js` and `_fresh/snapshot.js` contain forward slashes only
- [ ] Deploy Windows-built bundle to Linux — server starts without path errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)