### PR TITLE
fix: let node_modules asset requests pass through in dev mode

### DIFF
--- a/packages/plugin-vite/src/plugins/dev_server.ts
+++ b/packages/plugin-vite/src/plugins/dev_server.ts
@@ -29,9 +29,11 @@ export function devServer(): Plugin[] {
           // Don't cache in dev
           url.searchParams.delete(ASSET_CACHE_BUST_KEY);
 
-          // Check if it's a vite url
+          // Check if it's a vite url or a node_modules asset (e.g. fonts
+          // referenced from CSS in npm packages)
           if (
             IGNORE_URLS.test(url.pathname) ||
+            url.pathname.startsWith("/node_modules/") ||
             server.environments.client.moduleGraph.urlToModuleMap.has(
               url.pathname,
             ) ||


### PR DESCRIPTION
## Summary
- When CSS from npm packages (e.g. `@fontsource`) references font files (`.woff2`), the browser requests them at `/node_modules/...` paths
- Fresh's dev server middleware was intercepting these requests — they aren't in Vite's module graph (binary assets) and aren't in `publicDir`, so they fell through to the SSR handler which returned 404
- Fix: skip `/node_modules/` URLs in the middleware so Vite's built-in static file serving handles them

Reproduced with `@fontsource-variable/roboto` — font CSS is processed correctly but the `.woff2` file request gets 404'd.

Closes #3424

## Test plan
- [ ] `deno install npm:@fontsource-variable/roboto`, add `@import "@fontsource-variable/roboto"` to CSS
- [ ] `deno task dev` — font should load without 404 in browser console
- [ ] Verify normal routes and static files still work as before
- [ ] Production build should still work (this only affects dev server)

🤖 Generated with [Claude Code](https://claude.com/claude-code)