### PR TITLE
fix: dev server intercepts Vite URLs when basePath is configured

### DIFF
--- a/packages/plugin-vite/src/plugins/dev_server.ts
+++ b/packages/plugin-vite/src/plugins/dev_server.ts
@@ -14,7 +14,13 @@ export function devServer(): Plugin[] {
         publicDir = config.publicDir;
       },
       configureServer(server) {
-        const IGNORE_URLS = /^\/(@(vite|fs|id)|\.vite)\//;
+        // Build the ignore pattern accounting for the configured base path.
+        // Vite prefixes virtual module URLs with the base (e.g. /ui/@id/...),
+        // so we need to match both /@ and /base/@.
+        const base = server.config.base.replace(/\/$/, "");
+        const IGNORE_URLS = new RegExp(
+          `^(${base})?/(@(vite|fs|id)|\\.vite)/`,
+        );
 
         server.middlewares.use(async (nodeReq, nodeRes, next) => {
           const serverCfg = server.config.server;

--- a/packages/plugin-vite/tests/dev_server_test.ts
+++ b/packages/plugin-vite/tests/dev_server_test.ts
@@ -536,6 +536,24 @@ Deno.test({
   sanitizeResources: false,
 });
 
+// issue: https://github.com/denoland/fresh/issues/3666
+Deno.test({
+  name: "vite dev - basePath does not intercept Vite URLs",
+  fn: async () => {
+    const fixture = path.join(FIXTURE_DIR, "basepath");
+    await launchDevServer(fixture, async (address) => {
+      // `address` already includes the base path (e.g. http://localhost:PORT/ui)
+      // Vite's /@vite/client should be accessible at {base}/@vite/client
+      // Without the fix, Fresh's dev server intercepted this and returned 404.
+      const viteClientRes = await fetch(`${address}/@vite/client`);
+      await viteClientRes.body?.cancel();
+      expect(viteClientRes.status).toEqual(200);
+    });
+  },
+  sanitizeOps: false,
+  sanitizeResources: false,
+});
+
 Deno.test({
   name: "vite dev - source mapped stack traces",
   fn: async () => {

--- a/packages/plugin-vite/tests/fixtures/basepath/main.ts
+++ b/packages/plugin-vite/tests/fixtures/basepath/main.ts
@@ -1,0 +1,7 @@
+import { App, staticFiles } from "@fresh/core";
+
+export const app = new App({ basePath: "/ui" })
+  .use(staticFiles())
+  .get("/", () => new Response("<h1>ok</h1>", {
+    headers: { "Content-Type": "text/html" },
+  }));

--- a/packages/plugin-vite/tests/fixtures/basepath/main.ts
+++ b/packages/plugin-vite/tests/fixtures/basepath/main.ts
@@ -2,6 +2,7 @@ import { App, staticFiles } from "@fresh/core";
 
 export const app = new App({ basePath: "/ui" })
   .use(staticFiles())
-  .get("/", () => new Response("<h1>ok</h1>", {
-    headers: { "Content-Type": "text/html" },
-  }));
+  .get("/", () =>
+    new Response("<h1>ok</h1>", {
+      headers: { "Content-Type": "text/html" },
+    }));

--- a/packages/plugin-vite/tests/fixtures/basepath/vite.config.ts
+++ b/packages/plugin-vite/tests/fixtures/basepath/vite.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vite";
+import { fresh } from "@fresh/plugin-vite";
+
+export default defineConfig({
+  base: "/ui/",
+  plugins: [fresh()],
+});


### PR DESCRIPTION
## Summary

When `base: "/ui/"` is set in `vite.config.ts`, the Fresh dev server middleware intercepted Vite's virtual module URLs (like `/ui/@id/fresh:client-entry`) instead of passing them to Vite's middleware, causing 404s for client-entry JS and island code.

## Root cause

The `IGNORE_URLS` regex was hardcoded as `/^\/(@(vite|fs|id)|\.vite)\//`, which only matches URLs starting with `/@id/`, `/@vite/`, etc. When Vite's `base` is set to `/ui/`, virtual module URLs become `/ui/@id/...` which didn't match.

## Fix

Build the regex dynamically from `server.config.base`, matching both `/@id/...` and `/ui/@id/...`:

```ts
const base = server.config.base.replace(/\/$/, "");
const IGNORE_URLS = new RegExp(`^(${base})?/(@(vite|fs|id)|\\.vite)/`);
```

## Test plan

- [x] Verified `/ui/@id/fresh:client-entry` returns 200 (was 404)
- [x] Verified `/ui/@vite/client` returns 200 (was 404)
- [x] Verified `/@id/...` without base still works (backward compatible)

Closes #3666

🤖 Generated with [Claude Code](https://claude.com/claude-code)