### PR TITLE
ci: add perf prefix to PR title checker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,8 @@ jobs:
         env:
           TITLE: ${{ github.event.pull_request.title }}
         run: |
-          if ! echo "$TITLE" | grep -qP '^(chore|ci|docs|feat|fix|refactor|test):'; then
-            echo "::error::PR title must start with chore:, ci:, docs:, feat:, fix:, refactor: or test:"
+          if ! echo "$TITLE" | grep -qP '^(chore|ci|docs|feat|fix|perf|refactor|test):'; then
+            echo "::error::PR title must start with chore:, ci:, docs:, feat:, fix:, perf:, refactor: or test:"
             exit 1
           fi
 


### PR DESCRIPTION
## Summary
- Add `perf:` to the list of accepted PR title prefixes in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)