### PR TITLE
fix: use deno run for init instead of deno create before 2.3.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ with workspace members in `packages/*` and `www/`.
 - **`packages/plugin-vite/`** (`@fresh/plugin-vite`): Vite integration plugin
   with dev server, SSR/client builds, and HMR.
 - **`packages/init/`** (`@fresh/init`): Project scaffolding
-  (`deno create @fresh/init`).
+  (`deno run -Ar jsr:@fresh/init`).
 - **`packages/update/`** (`@fresh/update`): Automated Fresh 1.x to 2.x migration
   tool using ts-morph for AST transforms.
 - **`packages/build-id/`** (`@fresh/build-id`): Build/deployment ID generation.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ You can scaffold a new project by running the Fresh init script. To scaffold a
 project run the following:
 
 ```sh
-deno create @fresh/init
+deno run -Ar jsr:@fresh/init
 ```
 
 Then navigate to the newly created project folder:

--- a/docs/latest/getting-started/index.md
+++ b/docs/latest/getting-started/index.md
@@ -9,7 +9,7 @@ Let's set up your first Fresh project. To create a new project, run this
 command:
 
 ```sh Terminal
-deno create @fresh/init
+deno run -Ar jsr:@fresh/init
 ```
 
 This will spawn a short wizard that guides you through the setup, like the

--- a/docs/latest/introduction/index.md
+++ b/docs/latest/introduction/index.md
@@ -24,7 +24,7 @@ app.listen();
 Create a new Fresh app by running:
 
 ```sh Terminal
-deno create @fresh/init
+deno run -Ar jsr:@fresh/init
 ```
 
 ## Features

--- a/docs/latest/migration-guide/index.md
+++ b/docs/latest/migration-guide/index.md
@@ -314,7 +314,7 @@ to [update the command](/docs/deployment/deno-compile) to generate the binary.
 If you run into problems with upgrading your app, first, try starting a new
 Fresh 2 project and looking at the new structure.
 
-eg. `mkdir fresh2-demo && cd fresh2-demo && deno create @fresh/init`
+eg. `mkdir fresh2-demo && cd fresh2-demo && deno run -Ar jsr:@fresh/init`
 
 ### 2. Document
 

--- a/packages/fresh/README.md
+++ b/packages/fresh/README.md
@@ -11,7 +11,7 @@ web applications.
 Generate a new Fresh project with `@fresh/init`:
 
 ```sh
-deno create @fresh/init
+deno run -Ar jsr:@fresh/init
 ```
 
 Add middleware, routes, & endpoints as needed via the `routes/` folder or

--- a/packages/init/README.md
+++ b/packages/init/README.md
@@ -3,7 +3,7 @@
 This is a CLI tool to bootstrap a new Fresh project. To do so, run this command:
 
 ```sh
-deno create @fresh/init
+deno run -Ar jsr:@fresh/init
 ```
 
 Go to [https://fresh.deno.dev/](https://fresh.deno.dev/) for more information

--- a/packages/init/src/init.ts
+++ b/packages/init/src/init.ts
@@ -48,13 +48,13 @@ Initialize a new Fresh project. This will create all the necessary files
 for a new project.
 
 To generate a project in the './foobar' subdirectory:
-    ${colors.rgb8("deno create @fresh/init ./foobar", 245)}
+    ${colors.rgb8("deno run -Ar jsr:@fresh/init ./foobar", 245)}
 
 To generate a project in the current directory:
-    ${colors.rgb8("deno create @fresh/init .", 245)}
+    ${colors.rgb8("deno run -Ar jsr:@fresh/init .", 245)}
 
 ${colors.rgb8("USAGE:", 3)}
-    ${colors.rgb8("deno create @fresh/init [DIRECTORY]", 245)}
+    ${colors.rgb8("deno run -Ar jsr:@fresh/init [DIRECTORY]", 245)}
 
 ${colors.rgb8("OPTIONS:", 3)}
     ${colors.rgb8("--force", 2)}      Overwrite existing files

--- a/packages/init/src/mod.ts
+++ b/packages/init/src/mod.ts
@@ -2,11 +2,7 @@ import { parseArgs } from "@std/cli/parse-args";
 import { initProject } from "./init.ts";
 import { InitError } from "./init.ts";
 
-// deno-lint-ignore no-console
-console.warn(
-  "\x1b[33m%s\x1b[0m",
-  `Warning: "deno run -Ar jsr:@fresh/init" is deprecated. Use "deno create @fresh/init" instead.`,
-);
+// Note: "deno run -Ar jsr:@fresh/init" is the recommended way to create a new project.
 
 const flags = parseArgs(Deno.args, {
   boolean: ["force", "tailwind", "vscode", "docker", "help", "builder"],

--- a/www/components/homepage/Hero.tsx
+++ b/www/components/homepage/Hero.tsx
@@ -14,7 +14,7 @@ export function Hero() {
             </h2>
             <div class="mt-12 flex flex-wrap justify-center items-stretch md:justify-start gap-4">
               <FancyLink href="/docs/getting-started">Get started</FancyLink>
-              <CopyArea code={`deno create @fresh/init`} />
+              <CopyArea code={`deno run -Ar jsr:@fresh/init`} />
             </div>
           </div>
           <div class="md:col-span-2 flex justify-center items-end">


### PR DESCRIPTION
## Summary
- Reverts all references from `deno create @fresh/init` back to `deno run -Ar jsr:@fresh/init` across docs, READMEs, homepage, and CLI help text
- Removes the deprecation warning in `packages/init/src/mod.ts` that told users to switch to `deno create`

## Test plan
- [ ] Verify homepage copy-to-clipboard shows the correct command
- [ ] Verify docs pages render the correct init command
- [ ] Run `deno run -Ar jsr:@fresh/init --help` and confirm help text is correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)