### PR TITLE
fix: in sortRoutePaths: sort files alphabetically

### DIFF
--- a/packages/fresh/src/fs_routes.ts
+++ b/packages/fresh/src/fs_routes.ts
@@ -247,7 +247,7 @@ export function sortRoutePaths(a: string, b: string) {
       if (scoreA === scoreB) {
         if (charA !== charB) {
           // TODO: Do we need localeSort here or is this good enough?
-          return charA < charB ? 0 : 1;
+          return charA < charB ? -1 : 1;
         }
         continue;
       }
@@ -257,7 +257,7 @@ export function sortRoutePaths(a: string, b: string) {
 
     if (charA !== charB) {
       // TODO: Do we need localeSort here or is this good enough?
-      return charA < charB ? 0 : 1;
+      return charA < charB ? -1 : 1;
     }
 
     // If we're at the end of A or B, then we assume that the longer
@@ -292,8 +292,9 @@ function getRoutePathScore(char: string, s: string, i: number): number {
   }
 
   if (
-    i + 4 === s.length - 1 && char === "i" && s[i + 1] === "n" &&
-    s[i + 2] === "d" && s[i + 3] === "e" && s[i + 4] === "x"
+    char === "i" && s[i + 1] === "n" &&
+    s[i + 2] === "d" && s[i + 3] === "e" && s[i + 4] === "x" &&
+    (i + 4 === s.length - 1 || s[i + 5] === ".")
   ) {
     return 3;
   }

--- a/packages/fresh/src/fs_routes.ts
+++ b/packages/fresh/src/fs_routes.ts
@@ -246,7 +246,6 @@ export function sortRoutePaths(a: string, b: string) {
       const scoreB = getRoutePathScore(charB, b, bIdx);
       if (scoreA === scoreB) {
         if (charA !== charB) {
-          // TODO: Do we need localeSort here or is this good enough?
           return charA < charB ? -1 : 1;
         }
         continue;
@@ -256,7 +255,6 @@ export function sortRoutePaths(a: string, b: string) {
     }
 
     if (charA !== charB) {
-      // TODO: Do we need localeSort here or is this good enough?
       return charA < charB ? -1 : 1;
     }
 

--- a/packages/fresh/src/fs_routes_test.tsx
+++ b/packages/fresh/src/fs_routes_test.tsx
@@ -1315,6 +1315,8 @@ Deno.test("fsRoutes - sortRoutePaths with groups", () => {
 
   routes = [
     "/_app",
+    "/app",
+    "/app/_middleware",
     "/(authed)/_middleware",
     "/(authed)/_layout",
     "/_error",
@@ -1325,24 +1327,69 @@ Deno.test("fsRoutes - sortRoutePaths with groups", () => {
     "/(authed)/(account)/account",
     "/(authed)/api/slug",
     "/hooks/github",
+    "/(authed)/[org]/__foo",
     "/(authed)/[org]/_middleware",
     "/(authed)/[org]/index",
   ];
+  routes.sort(() => Math.random() > 0.5 ? -1 : 1);
   routes.sort(sortRoutePaths);
   sorted = [
     "/_app",
     "/_error",
-    "/login",
+    "/app/_middleware",
+    "/app",
     "/auth/login",
     "/auth/logout",
     "/hooks/github",
+    "/login",
     "/(authed)/_middleware",
     "/(authed)/_layout",
     "/(authed)/index",
     "/(authed)/api/slug",
     "/(authed)/(account)/account",
     "/(authed)/[org]/_middleware",
+    "/(authed)/[org]/__foo",
     "/(authed)/[org]/index",
+  ];
+  expect(routes).toEqual(sorted);
+
+  routes = [
+    "/_app.js",
+    "/app.tsx",
+    "/app/_middleware.tsx",
+    "/(authed)/_middleware.tsx",
+    "/(authed)/_layout.jsx",
+    "/_error.tsx",
+    "/(authed)/index.js",
+    "/login.js",
+    "/auth/logout.tsx",
+    "/auth/login.ts",
+    "/(authed)/(account)/account.tsx",
+    "/(authed)/api/slug.js",
+    "/hooks/github.js",
+    "/(authed)/[org]/__foo.js",
+    "/(authed)/[org]/_middleware.tsx",
+    "/(authed)/[org]/index.ts",
+  ];
+  routes.sort(() => Math.random() > 0.5 ? -1 : 1);
+  routes.sort(sortRoutePaths);
+  sorted = [
+    "/_app.js",
+    "/_error.tsx",
+    "/app/_middleware.tsx",
+    "/app.tsx",
+    "/auth/login.ts",
+    "/auth/logout.tsx",
+    "/hooks/github.js",
+    "/login.js",
+    "/(authed)/_middleware.tsx",
+    "/(authed)/_layout.jsx",
+    "/(authed)/index.js",
+    "/(authed)/api/slug.js",
+    "/(authed)/(account)/account.tsx",
+    "/(authed)/[org]/_middleware.tsx",
+    "/(authed)/[org]/__foo.js",
+    "/(authed)/[org]/index.ts",
   ];
   expect(routes).toEqual(sorted);
 });


### PR DESCRIPTION
The fix for the bug described was found with the assistance of Claude Opus 4.6. The analysis presented is from the AI, not my own, but I can confirm that the workaround it presented (which it said was based on its findings) did work for my use case.

## What I observed
For our fresh 2.2.0 project I observed that on github actions builds middleware defined in `routes/app/_middleware.tsx` were not running before the handler defined in `routes/app.tsx` after vite build. This was not the same behavior I observed when testing locally on my Mac.

I pulled down the generated `/_fresh` directory from github actions and instructed Claude to look to see if there were any differences in those files generated during the github actions build and those generated by running the same commands on my mac.

## From Claude Opus 4.6

```
@fresh/core's sortRoutePaths function has a bug on lines with return charA <
  charB ? 0 : 1 — when charA < charB, it returns 0 (equal) instead of -1 (a before b). This
  makes the comparator asymmetric: compare(a, b) can return 0 while compare(b, a) returns 1.

  On macOS, Deno.readDir returns files alphabetically, which happens to produce the correct
  final sort even with the broken comparator. On Linux (CI), Deno.readDir returns files in
  hash-table order. The stable TimSort algorithm + inconsistent comparator + different initial
  ordering = /app/_middleware ends up at position 112 instead of position 4, so the auth
  middleware never runs for /app routes.

  Fix: scripts/fix_fresh_route_order.ts re-sorts the fsRoutes array in
  _fresh/server/server-entry.mjs after the build using the correct comparator. It's wired into
  deno task build so it runs automatically on both local and CI.
  ```
  
The referenced workaround script [scripts/fix_fresh_route_order.ts](https://github.com/Virtual-Hospitals-Africa/virtual-hospitals-africa/blob/main/scripts/fix_fresh_route_order.ts) overwrites the route ordering in the generated `_fresh/server/server-entry.mjs` file after that has been built by `vite build`. While I have not evaluated the contents of that script line by line, I did scan it and it does seem to be doing what is suggested and I can confirm that it did fix the issue, suggesting that the overall analysis is sound.

Closes #3773