### PR TITLE
fix: handle commas in static file paths

### DIFF
--- a/packages/fresh/src/middlewares/static_files.ts
+++ b/packages/fresh/src/middlewares/static_files.ts
@@ -3,7 +3,14 @@ import { ASSET_CACHE_BUST_KEY } from "../constants.ts";
 import { BUILD_ID } from "@fresh/build-id";
 import { tracer } from "../otel.ts";
 import { getBuildCache } from "../context.ts";
-import { systemPathToUrlEncoded } from "../dev/dev_build_cache.ts";
+
+/** Decode and re-encode each path segment so that characters like commas
+ *  are percent-encoded consistently with how `prepareStaticFile` stores
+ *  entries in the build cache. */
+function normalizePathname(pathname: string): string {
+  return "/" +
+    pathname.split("/").filter(Boolean).map(encodeURIComponent).join("/");
+}
 
 /**
  * Fresh middleware to serve static files from the `static/` directory.
@@ -27,8 +34,9 @@ export function staticFiles<T>(): Middleware<T> {
     }
 
     try {
-      pathname = systemPathToUrlEncoded(decodeURIComponent(pathname));
-    } catch {
+      pathname = normalizePathname(decodeURIComponent(pathname));
+    } catch (_e: unknown) {
+      if (!(_e instanceof URIError)) throw _e;
       return await ctx.next();
     }
 

--- a/packages/fresh/src/middlewares/static_files.ts
+++ b/packages/fresh/src/middlewares/static_files.ts
@@ -3,6 +3,7 @@ import { ASSET_CACHE_BUST_KEY } from "../constants.ts";
 import { BUILD_ID } from "@fresh/build-id";
 import { tracer } from "../otel.ts";
 import { getBuildCache } from "../context.ts";
+import { systemPathToUrlEncoded } from "../dev/dev_build_cache.ts";
 
 /**
  * Fresh middleware to serve static files from the `static/` directory.
@@ -23,6 +24,12 @@ export function staticFiles<T>(): Middleware<T> {
       pathname = pathname !== config.basePath
         ? pathname.slice(config.basePath.length)
         : "/";
+    }
+
+    try {
+      pathname = systemPathToUrlEncoded(decodeURIComponent(pathname));
+    } catch {
+      return await ctx.next();
     }
 
     // Fast path bail out

--- a/packages/fresh/src/middlewares/static_files_test.ts
+++ b/packages/fresh/src/middlewares/static_files_test.ts
@@ -296,3 +296,29 @@ Deno.test("static files - fallthrough", async () => {
   expect(text).toEqual("it works");
   expect(called).toEqual(["before", "after"]);
 });
+
+Deno.test("static files - comma in pathname", async () => {
+  const key = systemPathToUrlEncoded("foo,bar.css");
+
+  const buildCache = new MockBuildCache({
+    [key]: {
+      content: "body {}",
+      hash: null,
+    },
+  });
+
+  const server = serveMiddleware(
+    staticFiles(),
+    { buildCache },
+  );
+
+  // Browser/request path usually keeps the comma unencoded
+  let res = await server.get("/foo,bar.css");
+  await res.body?.cancel();
+  expect(res.status).toEqual(200);
+
+  // Encoded form should also resolve
+  res = await server.get("/foo%2Cbar.css");
+  await res.body?.cancel();
+  expect(res.status).toEqual(200);
+});


### PR DESCRIPTION
## Problem

After #3659, static file handling correctly supports spaces and encoded paths,
but filenames containing commas are not resolved.

Example:
- File: `foo,bar.css`
- Stored in cache as: `/foo%2Cbar.css`
- Request: `/foo,bar.css`

This causes a mismatch and the static file is not found.

## Cause

`prepareStaticFile()` stores file paths using URL encoding, while
`static_files.ts` compares against `url.pathname` without applying the same
normalization.

## Solution

Normalize the incoming request pathname using the same encoding logic before
reading from the build cache.

## Tests

Added `static files - comma in pathname` to verify that both of these resolve:

- `/foo,bar.css`
- `/foo%2Cbar.css`