### PR TITLE
chore: release @fresh/plugin-vite@1.1.0 and @fresh/plugin-tailwind-v3@1.1.0

### DIFF
--- a/packages/plugin-tailwindcss-v3/deno.json
+++ b/packages/plugin-tailwindcss-v3/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@fresh/plugin-tailwind-v3",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "license": "MIT",
   "exports": "./src/mod.ts",
   "imports": {

--- a/packages/plugin-vite/deno.json
+++ b/packages/plugin-vite/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@fresh/plugin-vite",
-  "version": "1.0.8",
+  "version": "1.1.0",
   "license": "MIT",
   "exports": {
     ".": "./src/mod.ts",


### PR DESCRIPTION
## Summary

- Bump `@fresh/plugin-vite` from `1.0.8` → `1.1.0`
- Bump `@fresh/plugin-tailwind-v3` from `1.0.1` → `1.1.0`

These packages were not version-bumped during the 2.3.0 release despite having 18 and 1 unreleased changes respectively. Users on `@fresh/plugin-vite@1.0.8` are missing critical fixes including:

- **fix:** immutable caching for Vite-built assets (#3761) — island chunks served with `no-cache` instead of immutable headers
- **fix:** CSS modules in `_app/_layout/_error` and across routes in dev (#3764)
- **fix:** temp file watcher crash (#3763)
- **feat:** multiple `staticDir` entries (#3759)
- **fix:** CJS-to-ESM transform for npm compat (#3697)
- **fix:** Deno module resolution (#3734)
- **fix:** register Vite plugin-generated files in static cache (#3534)
- **fix:** basePath intercepts Vite URLs (#3730)
- **fix:** `<Head>` in client (#3252)
- And 9 more changes

Closes #3784

## Test plan
- CI passes
- After merge, `deno publish` workflow publishes both packages to JSR