### PR TITLE
ci: add dry-run publish check to PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,3 +78,7 @@ jobs:
       - name: Check links
         if: startsWith(matrix.os, 'ubuntu') && matrix.deno == 'v2.x'
         run: deno task check:links
+
+      - name: Dry-run publish
+        if: startsWith(matrix.os, 'ubuntu') && matrix.deno == 'v2.x'
+        run: deno publish --dry-run

--- a/deno.lock
+++ b/deno.lock
@@ -6111,17 +6111,6 @@
           "npm:vite@^7.1.4"
         ]
       }
-    },
-    "links": {
-      "npm:@deno/vite-plugin@2.0.2": {
-        "dependencies": [
-          "npm:@jsr/deno__loader@0.5",
-          "npm:@jsr/std__jsonc@1"
-        ],
-        "peerDependencies": [
-          "npm:vite@5 || 6 || 7 || 8"
-        ]
-      }
     }
   }
 }


### PR DESCRIPTION
## Summary

- Adds `deno publish --dry-run` step to CI (ubuntu, v2.x only)
- Catches lockfile mismatches and other publish issues in PRs before they hit main
- Prevents the recurring problem of releases failing to publish after merge

## Test plan
- CI on this PR should itself run the new dry-publish step and pass