### PR TITLE
chore: release 2.3.1

### DIFF
--- a/packages/fresh/deno.json
+++ b/packages/fresh/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@fresh/core",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "license": "MIT",
   "exports": {
     ".": "./src/mod.ts",

--- a/packages/init/deno.json
+++ b/packages/init/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@fresh/init",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "license": "MIT",
   "exports": {
     ".": "./src/mod.ts",

--- a/packages/init/src/init.ts
+++ b/packages/init/src/init.ts
@@ -5,9 +5,9 @@ import * as semver from "@std/semver";
 import initConfig from "../deno.json" with { type: "json" };
 
 // Keep these as is, as we replace these version in our release script
-const FRESH_VERSION = "2.3.0";
+const FRESH_VERSION = "2.3.1";
 const FRESH_TAILWIND_VERSION = "1.0.0";
-const FRESH_VITE_PLUGIN = "1.0.0";
+const FRESH_VITE_PLUGIN = "1.1.0";
 const PREACT_VERSION = "10.29.1";
 const PREACT_SIGNALS_VERSION = "2.9.0";
 const TAILWINDCSS_VERSION = "4.1.10";

--- a/packages/plugin-tailwindcss-v3/deno.json
+++ b/packages/plugin-tailwindcss-v3/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@fresh/plugin-tailwind-v3",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "license": "MIT",
   "exports": "./src/mod.ts",
   "imports": {

--- a/packages/plugin-vite/deno.json
+++ b/packages/plugin-vite/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@fresh/plugin-vite",
-  "version": "1.0.8",
+  "version": "1.1.0",
   "license": "MIT",
   "exports": {
     ".": "./src/mod.ts",

--- a/packages/update/deno.json
+++ b/packages/update/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@fresh/update",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "license": "MIT",
   "exports": "./src/mod.ts",
   "exclude": ["**/tmp/*"],

--- a/packages/update/src/update.ts
+++ b/packages/update/src/update.ts
@@ -7,7 +7,7 @@ import { walk } from "@std/fs/walk";
 
 export const SyntaxKind = tsmorph.ts.SyntaxKind;
 
-export const FRESH_VERSION = "2.3.0";
+export const FRESH_VERSION = "2.3.1";
 export const PREACT_VERSION = "10.29.1";
 export const PREACT_SIGNALS_VERSION = "2.9.0";
 


### PR DESCRIPTION
## Summary

- Bump `@fresh/core` to `2.3.1`
- Bump `@fresh/init` to `2.3.1`
- Bump `@fresh/update` to `2.3.1`
- Bump `@fresh/plugin-vite` from `1.0.8` to `1.1.0`
- Bump `@fresh/plugin-tailwind-v3` from `1.0.1` to `1.1.0`

The plugin packages were not published during the 2.3.0 release despite having significant changes merged. Notable fixes in `@fresh/plugin-vite` include immutable caching for Vite-built assets (#3761), CSS modules in layouts (#3764), and multiple `staticDir` support (#3759).

Also updates `FRESH_VITE_PLUGIN` version constant in `@fresh/init` so new projects scaffold with the correct plugin version.

Closes #3784

## Test plan
- CI passes
- After merge, `deno publish` workflow publishes all bumped packages to JSR