### PR TITLE
docs: remove claim that node_modules is not necessary

### DIFF
--- a/www/components/homepage/Hero.tsx
+++ b/www/components/homepage/Hero.tsx
@@ -14,7 +14,7 @@ export function Hero() {
               The framework so simple, you already know it.
             </h2>
             <p class="mt-6 text-lg sm:text-xl text-gray-700 text-balance max-w-prose">
-              No config files, no build step, no node_modules. Just one file and
+              No config files, no build step. Just one file and
               you have a server with routing, JSX, and islands.
             </p>
             <div class="mt-12 flex flex-wrap justify-center items-stretch md:justify-start gap-4">

--- a/www/components/homepage/Simple.tsx
+++ b/www/components/homepage/Simple.tsx
@@ -44,7 +44,7 @@ export function Simple() {
           The framework so simple, you already know it.
         </h2>
         <p class="text-xl text-balance max-w-prose mx-auto">
-          No config files, no build step, no node_modules. Just one file and you
+          No config files, no build step. Just one file and you
           have a server with routing, JSX, and islands.
         </p>
       </div>


### PR DESCRIPTION
This was true for Fresh 1.x. `deno run -Ar jsr:@fresh/init` creates `node_modules`.