### PR TITLE
chore: release 2.3.2

### DIFF
--- a/packages/fresh/deno.json
+++ b/packages/fresh/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@fresh/core",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "license": "MIT",
   "exports": {
     ".": "./src/mod.ts",

--- a/packages/init/deno.json
+++ b/packages/init/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@fresh/init",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "license": "MIT",
   "exports": {
     ".": "./src/mod.ts",

--- a/packages/init/src/init.ts
+++ b/packages/init/src/init.ts
@@ -5,9 +5,9 @@ import * as semver from "@std/semver";
 import initConfig from "../deno.json" with { type: "json" };
 
 // Keep these as is, as we replace these version in our release script
-const FRESH_VERSION = "2.3.1";
+const FRESH_VERSION = "2.3.2";
 const FRESH_TAILWIND_VERSION = "1.0.0";
-const FRESH_VITE_PLUGIN = "1.1.0";
+const FRESH_VITE_PLUGIN = "1.1.1";
 const PREACT_VERSION = "10.29.1";
 const PREACT_SIGNALS_VERSION = "2.9.0";
 const TAILWINDCSS_VERSION = "4.1.10";

--- a/packages/plugin-vite/deno.json
+++ b/packages/plugin-vite/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@fresh/plugin-vite",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "license": "MIT",
   "exports": {
     ".": "./src/mod.ts",

--- a/packages/update/deno.json
+++ b/packages/update/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@fresh/update",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "license": "MIT",
   "exports": "./src/mod.ts",
   "exclude": ["**/tmp/*"],

--- a/packages/update/src/update.ts
+++ b/packages/update/src/update.ts
@@ -7,7 +7,7 @@ import { walk } from "@std/fs/walk";
 
 export const SyntaxKind = tsmorph.ts.SyntaxKind;
 
-export const FRESH_VERSION = "2.3.1";
+export const FRESH_VERSION = "2.3.2";
 export const PREACT_VERSION = "10.29.1";
 export const PREACT_SIGNALS_VERSION = "2.9.0";
 


### PR DESCRIPTION
## Summary

- Bump `@fresh/core` 2.3.1 → 2.3.2
- Bump `@fresh/plugin-vite` 1.1.0 → 1.1.1
- Bump `@fresh/init` 2.3.1 → 2.3.2
- Bump `@fresh/update` 2.3.1 → 2.3.2

Patch release for the CJS detection regression fix (#3793).